### PR TITLE
Simplify min/sort comparisons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["algorithms", "data-structures"]
 keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 
+[dependencies]
+ordered-float = "1.0.1"
+
 [dev-dependencies]
 criterion = "0.2.5"
 rand = "0.5.5"

--- a/examples/triangulate.rs
+++ b/examples/triangulate.rs
@@ -13,7 +13,7 @@ fn main() {
         .collect();
 
     let now = std::time::Instant::now();
-    let result = delaunator::triangulate(&points);
+    let result = delaunator::triangulate(&points).unwrap();
     let elapsed = now.elapsed();
 
     println!(


### PR DESCRIPTION
 - Use ordered-float crate that provides strong ordering on floats by ignoring IEEE.754 spec in terms of handling NaN (which is what we did anyway). This allows to use *_by_key functions for comparisons on iterables.
 - Change public API to return Option, so that when triangulation doesn't exist, None would be returned instead of panicking (this is more idiomatic in Rust).