### PR TITLE
Fixes mourner/delaunator-rs#8 - panics index out of bounds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ impl Triangulation {
 
     /// The number of triangles in the triangulation.
     pub fn len(&self) -> usize {
-        (self.triangles.len() / 3)
+        self.triangles.len() / 3
     }
 
     fn add_triangle(
@@ -233,7 +233,7 @@ impl Triangulation {
                         hull.tri[e] = a;
                         break;
                     }
-                    e = hull.next[e];
+                    e = hull.prev[e];
                     if e == hull.start {
                         break;
                     }


### PR DESCRIPTION
I believe this fixes #8 
I was able to narrow a repro with the following smaller set of points:

```rust
fn main() {
    let s = vec![
        Point { x: -0.2, y: -0.26 },
        Point { x: -0.5, y: -0.57 },
        Point { x: -0.06, y: 0.4 },
        Point { x: 0.0, y: 0.47 },
        Point { x: 0.6, y: 0.0 },
        Point { x: -0.9, y: -0.8 },
    ];

    triangulate(&s);
}
```

Which now passes. This error was happening on my 10M random point benchmark, which now passes consistently with this patch.

I haven't yet got a chance to validate the correctness of the generated triangulation. I'll do that next, but wanted to get the PR out for early review.

Comparing with the [javascript implementation](https://github.com/mapbox/delaunator/blob/f0ed80d9232dbe32b1a989eee227700e0491f1be/index.js#L324) this seems to match the implementation there, so it gives me some hope this is the right fix.