### PR TITLE
Remove recursion

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -76,6 +76,7 @@ fn validate(points: &[Point]) {
         triangles,
         halfedges,
         hull,
+        ..
     } = triangulate(&points).expect("No triangulation exists for this input");
 
     // validate halfedges

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -76,7 +76,6 @@ fn validate(points: &[Point]) {
         triangles,
         halfedges,
         hull,
-        ..
     } = triangulate(&points).expect("No triangulation exists for this input");
 
     // validate halfedges


### PR DESCRIPTION
This is the port for the fix to remove recursion in the legalize method. First issue tracked in #15 

From benchmarks, it seems the loop approach is slightly worse than the recursion approach (numbers below).

My first commit was actually much worse, because I had the ```edge_stack``` in the stack, which was getting initialized on each method call. I had to move the ```edge_stack``` in the triangulation type to avoid a global variable, which would make cause problems for folks wanting to use this create with multiple threads. Still, it is not ideal to keep it there as it takes unnecessary memory. Another alternative is to use a [unsafe array initializer](https://www.joshmcguigan.com/blog/array-initialization-rust/) but then it taints the create with unsafe.

I will try to dig a bit more later to see if I can tweak this; but my guess is that I won't be able to beat the compile and the recursion implementation was probably getting optimized out by the compiler quite well.

I am unsure if we should take this change, but I am sending the PR anyways with the details so we can review and decide.

Bench for master right now
```
triangulate/100         time:   [17.412 us 17.510 us 17.658 us]                            
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
triangulate/1000        time:   [249.41 us 250.44 us 252.33 us]                            
Found 3 outliers among 20 measurements (15.00%)
  1 (5.00%) high mild
  2 (10.00%) high severe
triangulate/10000       time:   [3.2132 ms 3.2291 ms 3.2552 ms]                              
Found 4 outliers among 20 measurements (20.00%)
  4 (20.00%) high severe
triangulate/100000      time:   [47.804 ms 48.003 ms 48.293 ms]                              
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe
```

Bench after this change:
```
triangulate/100         time:   [19.405 us 19.498 us 19.591 us]                            
                        change: [+10.503% +11.068% +11.579%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 20 measurements (15.00%)
  3 (15.00%) high severe
triangulate/1000        time:   [251.40 us 253.38 us 255.88 us]                            
                        change: [+0.3120% +0.9845% +1.6889%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
triangulate/10000       time:   [3.2142 ms 3.2216 ms 3.2329 ms]                              
                        change: [-0.6539% -0.0132% +0.5873%] (p = 0.97 > 0.05)
                        No change in performance detected.
triangulate/100000      time:   [48.406 ms 48.505 ms 48.613 ms]                              
                        change: [+0.4143% +1.0451% +1.5393%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 20 measurements (20.00%)
  2 (10.00%) low mild
  1 (5.00%) high mild
  1 (5.00%) high severe

```