### PR TITLE
Return an ordered set of points if they are collinear (ports mapbox/delaunator/pull/47)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delaunator"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 description = "A very fast 2D Delaunay triangulation library."
 documentation = "https://docs.rs/delaunator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "delaunator"
 version = "0.2.1"
+edition = "2018"
 description = "A very fast 2D Delaunay triangulation library."
 documentation = "https://docs.rs/delaunator"
 repository = "https://github.com/mourner/delaunator-rs"

--- a/examples/triangulate.rs
+++ b/examples/triangulate.rs
@@ -12,7 +12,7 @@ fn main() {
         .collect();
 
     let now = std::time::Instant::now();
-    let result = delaunator::triangulate(&points).expect("No triangulation exists for this input.");
+    let result = delaunator::triangulate(&points);
     let elapsed = now.elapsed();
 
     println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,6 @@ fn handle_collinear_points(points: &[Point]) -> Triangulation {
         })
         .collect();
     sortf(&mut dist);
-    println!("{:?}", dist);
 
     let mut triangulation = Triangulation::new(0);
     let mut d0 = f64::NEG_INFINITY;


### PR DESCRIPTION
This PR addresses the second issued tracked at #15 - returns ordered points on the hull with an empty triangulation (no triangles/edges) if input points are collinear.

This is contract breaking as ```triangulate()``` now returns ```Triangulation``` instead  of ```Option<Triangulation>```.

When the set of input points is empty, the returned ```Triangulation``` is empty (no triangles, edges or hull).