### PR TITLE
Change package to use `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 
 [dependencies]
-cfg-if = "1"
 micromath = "2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ categories = ["algorithms", "data-structures"]
 keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 
-[dependencies]
-micromath = "2"
-
 [dev-dependencies]
 criterion = "0.3.4"
 rand = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,18 @@ categories = ["algorithms", "data-structures"]
 keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 
+[dependencies]
+cfg-if = "1"
+micromath = "2"
+
 [dev-dependencies]
 criterion = "0.3.4"
 rand = "0.8.3"
 serde_json = "1.0.64"
+
+[features]
+default = ["std"]
+std = []
 
 [lib]
 bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,6 @@ println!("{:?}", result.triangles); // [0, 2, 1, 0, 3, 2]
 
 #![no_std]
 
-#[cfg(not(feature = "std"))]
-use micromath::F32Ext;
-
 #[cfg(feature = "std")]
 extern crate std;
 
@@ -593,7 +590,11 @@ fn f64_floor(f: f64) -> f64 {
 #[cfg(not(feature = "std"))]
 #[inline]
 fn f64_floor(f: f64) -> f64 {
-    (f as f32).floor() as f64
+    let mut res = (f as i64) as f64;
+    if res > f {
+        res -= 1.0;
+    }
+    res as f64
 }
 
 #[cfg(feature = "std")]
@@ -605,5 +606,14 @@ fn f64_sqrt(f: f64) -> f64 {
 #[cfg(not(feature = "std"))]
 #[inline]
 fn f64_sqrt(f: f64) -> f64 {
-    (f as f32).sqrt() as f64
+    if f < 2.0 { return f; };
+
+    let sc = f64_sqrt(f / 4.0) * 2.0;
+    let lc = sc + 1.0;
+    
+    if lc * lc > f {
+        sc
+    } else {
+        lc
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,36 +571,39 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
     triangulation
 }
 
+#[cfg(feature = "std")]
 #[inline]
 fn f64_abs(f: f64) -> f64 {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "std")] {
-            f.abs()
-        } else {
-            const SIGN_BIT: u64 = 1 << 63;
-            f64::from_bits(f64::to_bits(f) & !SIGN_BIT)
-        }
-    }
+    f.abs()
 }
 
+#[cfg(not(feature = "std"))]
+#[inline]
+fn f64_abs(f: f64) -> f64 {
+    const SIGN_BIT: u64 = 1 << 63;
+    f64::from_bits(f64::to_bits(f) & !SIGN_BIT)
+}
+
+#[cfg(feature = "std")]
 #[inline]
 fn f64_floor(f: f64) -> f64 {
-    cfg_if::cfg_if! {
-         if #[cfg(feature = "std")] {
-            f.floor()
-        } else {
-            (f as f32).floor() as f64
-        }   
-    }
+    f.floor()
 }
 
+#[cfg(not(feature = "std"))]
+#[inline]
+fn f64_floor(f: f64) -> f64 {
+    (f as f32).floor() as f64
+}
+
+#[cfg(feature = "std")]
 #[inline]
 fn f64_sqrt(f: f64) -> f64 {
-    cfg_if::cfg_if! {
-         if #[cfg(feature = "std")] {
-            f.sqrt()
-        } else {
-            (f as f32).sqrt() as f64
-        }   
-    }
+    f.sqrt()
+}
+
+#[cfg(not(feature = "std"))]
+#[inline]
+fn f64_sqrt(f: f64) -> f64 {
+    (f as f32).sqrt() as f64
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ println!("{:?}", result.triangles); // [0, 2, 1, 0, 3, 2]
 
 #![no_std]
 
+#[macro_use]
 extern crate alloc;
 
 use core::{f64, fmt};
@@ -98,7 +99,7 @@ impl Point {
     }
 
     fn nearly_equals(&self, p: &Self) -> bool {
-        (self.x - p.x).abs() <= EPSILON && (self.y - p.y).abs() <= EPSILON
+        f64_abs(self.x - p.x) <= EPSILON && f64_abs(self.y - p.y) <= EPSILON
     }
 }
 
@@ -562,4 +563,11 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
     triangulation.halfedges.shrink_to_fit();
 
     triangulation
+}
+
+#[inline]
+fn abs_f64(f: f64) -> f64 {
+    // IEEE standard specifies that the 64th bit of an f64 is the sign bit
+    const SIGN_BIT: u64 = 1 << 63;
+    f64::from_bits(f64::to_bits(f) & !SIGN_BIT)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,7 +566,7 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
 }
 
 #[inline]
-fn abs_f64(f: f64) -> f64 {
+fn f64_abs(f: f64) -> f64 {
     // IEEE standard specifies that the 64th bit of an f64 is the sign bit
     const SIGN_BIT: u64 = 1 << 63;
     f64::from_bits(f64::to_bits(f) & !SIGN_BIT)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,12 @@ println!("{:?}", result.triangles); // [0, 2, 1, 0, 3, 2]
 ```
 */
 
-use std::{f64, fmt};
+#![no_std]
+
+extern crate alloc;
+
+use core::{f64, fmt};
+use alloc::vec::Vec;
 
 /// Near-duplicate points (where both `x` and `y` only differ within this value)
 /// will not be included in the triangulation for robustness.


### PR DESCRIPTION
This pull requests replaces all dependencies on libstd to dependencies on libcore and liballoc, so that this algorithm can be used on targets that do not have access to the standard library.