### PR TITLE
Fixed panic when NaN is passed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate std;
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::{f64, fmt};
+use core::{f64, fmt, cmp::Ordering};
 use robust::orient2d;
 
 /// Near-duplicate points (where both `x` and `y` only differ within this value)
@@ -441,7 +441,7 @@ fn find_seed_triangle(points: &[Point]) -> Option<(usize, usize, usize)> {
 }
 
 fn sortf(f: &mut [(usize, f64)]) {
-    f.sort_unstable_by(|&(_, da), &(_, db)| da.partial_cmp(&db).unwrap());
+    f.sort_unstable_by(|&(_, da), &(_, db)| da.partial_cmp(&db).unwrap_or(Ordering::Equal));
 }
 
 /// Order collinear points by dx (or dy if all x are identical) and return the list as a hull

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate std;
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::{f64, fmt, cmp::Ordering};
+use core::{cmp::Ordering, f64, fmt};
 use robust::orient2d;
 
 /// Near-duplicate points (where both `x` and `y` only differ within this value)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -159,7 +159,7 @@ fn hull_collinear_issue24() {
 }
 
 #[test]
-/// The test ensures that even when an invalid sequence of points is passed, there is no panic. 
+/// The test ensures that even when an invalid sequence of points is passed, there is no panic.
 /// In this test, the output does not matter as long as an output is returned.
 fn invalid_nan_sequence() {
     let points = vec![

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -158,6 +158,25 @@ fn hull_collinear_issue24() {
     assert_eq!(t.hull, &[0, 3, 2, 1], "Invalid hull");
 }
 
+#[test]
+/// The test ensures that even when an invalid sequence of points is passed, there is no panic. 
+/// In this test, the output does not matter as long as an output is returned.
+fn invalid_nan_sequence() {
+    let points = vec![
+        Point { x: -3.5, y: -1.5 },
+        Point {
+            x: f64::NAN,
+            y: f64::NAN,
+        },
+        Point {
+            x: f64::NAN,
+            y: f64::NAN,
+        },
+        Point { x: -3.5, y: -1.5 },
+    ];
+    triangulate(&points);
+}
+
 fn scale_points(points: &[Point], scale: f64) -> Vec<Point> {
     let scaled: Vec<Point> = points
         .iter()


### PR DESCRIPTION
Previously, the triangulation panicked when NaN was passed because there was no fall back to equal in the sort comparison.