### PR TITLE
`core::f64` has been deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 
 [dependencies]
-robust = "0.2.3"
+robust = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate std;
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::{cmp::Ordering, f64, fmt};
+use core::{cmp::Ordering, fmt};
 use robust::orient2d;
 
 /// Near-duplicate points (where both `x` and `y` only differ within this value)
@@ -121,7 +121,7 @@ impl Point {
 /// Represents the area outside of the triangulation.
 /// Halfedges on the convex hull (which don't have an adjacent halfedge)
 /// will have this value.
-pub const EMPTY: usize = usize::max_value();
+pub const EMPTY: usize = usize::MAX;
 
 /// Next halfedge in a triangle.
 pub fn next_halfedge(i: usize) -> usize {


### PR DESCRIPTION
Replace deprecated api

- https://doc.rust-lang.org/core/f64/constant.EPSILON.html
- https://doc.rust-lang.org/std/primitive.usize.html#method.max_value