### PR TITLE
Minor: Bump criterion to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 robust = "1.0.0"
 
 [dev-dependencies]
-criterion = "0.4.0"
+criterion = "0.5.1"
 rand = "0.8.5"
 serde_json = "1.0.94"
 


### PR DESCRIPTION
running cargo outdated .. shows this issue.

Manual testing 

cargo test ...  works
cargo bench .. works

I hope this helps.
