### PR TITLE
Allow From/Into conversions of `Point` and tuple/arrays of `f64`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,30 @@ impl From<&Point> for robust::Coord<f64> {
     }
 }
 
+impl From<(f64, f64)> for Point {
+    fn from((x, y): (f64, f64)) -> Self {
+        Point { x, y }
+    }
+}
+
+impl From<[f64; 2]> for Point {
+    fn from([x, y]: [f64; 2]) -> Self {
+        Point { x, y }
+    }
+}
+
+impl From<Point> for (f64, f64) {
+    fn from(pt: Point) -> Self {
+        (pt.x, pt.y)
+    }
+}
+
+impl From<Point> for [f64; 2] {
+    fn from(pt: Point) -> Self {
+        [pt.x, pt.y]
+    }
+}
+
 impl Point {
     fn dist2(&self, p: &Self) -> f64 {
         let dx = self.x - p.x;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -177,6 +177,18 @@ fn invalid_nan_sequence() {
     triangulate(&points);
 }
 
+#[test]
+/// The test demonstrates and validates our tuple and array round tripping of `Point`
+fn tuple_array_conv() {
+    // Tuple/Array --> Point
+    assert_eq!(Into::<Point>::into((1., 2.)), Point { x: 1., y: 2. });
+    assert_eq!(Into::<Point>::into([1., 2.]), Point { x: 1., y: 2. });
+
+    // Point --> Tuple/Array
+    assert_eq!(Into::<(f64, f64)>::into(Point { x: 1., y: 2. }), (1., 2.));
+    assert_eq!(Into::<[f64; 2]>::into(Point { x: 1., y: 2. }), [1., 2.]);
+}
+
 fn scale_points(points: &[Point], scale: f64) -> Vec<Point> {
     let scaled: Vec<Point> = points
         .iter()


### PR DESCRIPTION
This is a common pattern that I like to use for various linear algebra work in Rust:
```rust
let points: &[Some2DPoint] = &[
   (0., 1.).into(),
   (1., 0.).into(),
   (1., 1.).into(),
];
```

Subjectively, it's cleaner. It also helps with interop across math frameworks, since many of them can round trip through tuples or arrays. In C, these types are often unions anyway.

This change adds impls for `From` (and by extension `Into`) to allow round tripping `Point`, `(f64, 64)`, and `[f64; 2]`. It's a small change with a simple API expansion and simple implementation + tests.

I make use of this so maybe someone else will benefit here. :)