### PR TITLE
Chore: Fixed cargo outdated issues.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 
 [dependencies]
-robust = "1.0.0"
+robust = "1.1.0"
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
-serde_json = "1.0.94"
+serde_json = "1.0.114"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Here is a list of deprecated modules, as list by

```cargo outdated```.

This PR clears them.
```
Name                                              Project  Compat   Latest   Kind         Platform
----                                              -------  ------   ------   ----         --------
aho-corasick->memchr                              2.6.4    2.7.1    2.7.1    Normal       ---
ciborium->ciborium-io                             0.2.1    0.2.2    0.2.2    Normal       ---
ciborium->ciborium-ll                             0.2.1    0.2.2    0.2.2    Normal       ---
ciborium-ll->ciborium-io                          0.2.1    0.2.2    0.2.2    Normal       ---
ciborium-ll->half                                 1.8.2    2.4.0    2.4.0    Normal       ---
clap->clap_builder                                4.4.7    4.5.1    4.5.1    Normal       ---
clap_builder->anstyle                             1.0.4    1.0.6    1.0.6    Normal       ---
clap_builder->clap_lex                            0.6.0    0.7.0    0.7.0    Normal       ---
criterion->ciborium                               0.2.1    0.2.2    0.2.2    Normal       ---
criterion->clap                                   4.4.7    4.5.1    4.5.1    Normal       ---
criterion->is-terminal                            0.4.9    0.4.12   0.4.12   Normal       ---
criterion->num-traits                             0.2.17   0.2.18   0.2.18   Normal       ---
criterion->once_cell                              1.18.0   1.19.0   1.19.0   Normal       ---
criterion->rayon                                  1.8.0    1.9.0    1.9.0    Normal       ---
criterion->regex                                  1.10.2   1.10.3   1.10.3   Normal       ---
crossbeam-deque->cfg-if                           1.0.0    Removed  Removed  Normal       ---
crossbeam-deque->crossbeam-epoch                  0.9.15   0.9.18   0.9.18   Normal       ---
crossbeam-deque->crossbeam-utils                  0.8.16   0.8.19   0.8.19   Normal       ---
crossbeam-epoch->autocfg                          1.1.0    Removed  Removed  Build        ---
crossbeam-epoch->cfg-if                           1.0.0    Removed  Removed  Normal       ---
crossbeam-epoch->crossbeam-utils                  0.8.16   0.8.19   0.8.19   Normal       ---
crossbeam-epoch->memoffset                        0.9.0    Removed  Removed  Normal       ---
crossbeam-epoch->scopeguard                       1.2.0    Removed  Removed  Normal       ---
crossbeam-utils->cfg-if                           1.0.0    Removed  Removed  Normal       ---
errno->libc                                       0.2.149  Removed  Removed  Normal       cfg(target_os = "hermit")
errno->windows-sys                                0.48.0   Removed  Removed  Normal       cfg(windows)
getrandom->libc                                   0.2.149  0.2.153  0.2.153  Normal       cfg(unix)
is-terminal->hermit-abi                           0.3.3    0.3.8    0.3.8    Normal       cfg(target_os = "hermit")
is-terminal->rustix                               0.38.21  Removed  Removed  Normal       cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))
is-terminal->windows-sys                          0.48.0   0.52.0   0.52.0   Normal       cfg(windows)
itertools->either                                 1.9.0    1.10.0   1.10.0   Normal       ---
js-sys->wasm-bindgen                              0.2.87   0.2.91   0.2.91   Normal       ---
memoffset->autocfg                                1.1.0    Removed  Removed  Build        ---
plotters->num-traits                              0.2.17   0.2.18   0.2.18   Normal       ---
plotters->wasm-bindgen                            0.2.87   0.2.91   0.2.91   Normal       cfg(all(target_arch = "wasm32", not(target_os = "wasi")))
plotters->web-sys                                 0.3.64   0.3.68   0.3.68   Normal       cfg(all(target_arch = "wasm32", not(target_os = "wasi")))
rand->libc                                        0.2.149  0.2.153  0.2.153  Normal       cfg(unix)
rand_core->getrandom                              0.2.10   0.2.12   0.2.12   Normal       ---
rayon->either                                     1.9.0    1.10.0   1.10.0   Normal       ---
rayon->rayon-core                                 1.12.0   1.12.1   1.12.1   Normal       ---
rayon-core->crossbeam-deque                       0.8.3    0.8.5    0.8.5    Normal       ---
rayon-core->crossbeam-utils                       0.8.16   0.8.19   0.8.19   Normal       ---
regex->memchr                                     2.6.4    2.7.1    2.7.1    Normal       ---
regex->regex-automata                             0.4.3    0.4.5    0.4.5    Normal       ---
regex-automata->memchr                            2.6.4    2.7.1    2.7.1    Normal       ---
rustix->bitflags                                  2.4.1    Removed  Removed  Normal       ---
rustix->errno                                     0.3.5    Removed  Removed  Development  ---
rustix->libc                                      0.2.149  Removed  Removed  Development  ---
rustix->linux-raw-sys                             0.4.10   Removed  Removed  Normal       cfg(all(any(target_os = "android", target_os = "linux"), any(rustix_use_libc, miri, not(all(target_os = "linux", target_endian = "little", any(target_arch = "arm", all(target_arch = "aarch64", target_pointer_width = "64"), target_arch = "riscv64", all(rustix_use_experimental_asm, target_arch = "powerpc64"), all(rustix_use_experimental_asm, target_arch = "mips"), all(rustix_use_experimental_asm, target_arch = "mips32r6"), all(rustix_use_experimental_asm, target_arch = "mips64"), all(rustix_use_experimental_asm, target_arch = "mips64r6"), target_arch = "x86", all(target_arch = "x86_64", target_pointer_width = "64")))))))
rustix->windows-sys                               0.48.0   Removed  Removed  Normal       cfg(windows)
serde_json->itoa                                  1.0.9    1.0.10   1.0.10   Normal       ---
serde_json->ryu                                   1.0.15   1.0.17   1.0.17   Normal       ---
wasm-bindgen->wasm-bindgen-macro                  0.2.87   0.2.91   0.2.91   Normal       ---
wasm-bindgen-backend->bumpalo                     3.14.0   3.15.3   3.15.3   Normal       ---
wasm-bindgen-backend->once_cell                   1.18.0   1.19.0   1.19.0   Normal       ---
wasm-bindgen-backend->wasm-bindgen-shared         0.2.87   0.2.91   0.2.91   Normal       ---
wasm-bindgen-macro->wasm-bindgen-macro-support    0.2.87   0.2.91   0.2.91   Normal       ---
wasm-bindgen-macro-support->wasm-bindgen-backend  0.2.87   0.2.91   0.2.91   Normal       ---
wasm-bindgen-macro-support->wasm-bindgen-shared   0.2.87   0.2.91   0.2.91   Normal       ---
web-sys->js-sys                                   0.3.64   0.3.68   0.3.68   Normal       ---
web-sys->wasm-bindgen                             0.2.87   0.2.91   0.2.91   Normal       ---
windows-sys->windows-targets                      0.48.5   0.52.4   0.52.4   Normal       ---
windows-sys->windows-targets                      0.48.5   Removed  Removed  Normal       ---
windows-targets->windows_aarch64_gnullvm          0.48.5   0.52.4   0.52.4   Normal       aarch64-pc-windows-gnullvm
windows-targets->windows_aarch64_gnullvm          0.48.5   Removed  Removed  Normal       aarch64-pc-windows-gnullvm
windows-targets->windows_aarch64_msvc             0.48.5   0.52.4   0.52.4   Normal       cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_aarch64_msvc             0.48.5   Removed  Removed  Normal       cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_i686_gnu                 0.48.5   0.52.4   0.52.4   Normal       cfg(all(target_arch = "x86", target_env = "gnu", not(windows_raw_dylib)))
windows-targets->windows_i686_gnu                 0.48.5   Removed  Removed  Normal       cfg(all(target_arch = "x86", target_env = "gnu", not(windows_raw_dylib)))
windows-targets->windows_i686_msvc                0.48.5   0.52.4   0.52.4   Normal       cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_i686_msvc                0.48.5   Removed  Removed  Normal       cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnu               0.48.5   0.52.4   0.52.4   Normal       cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnu               0.48.5   Removed  Removed  Normal       cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))
windows-targets->windows_x86_64_gnullvm           0.48.5   0.52.4   0.52.4   Normal       x86_64-pc-windows-gnullvm
windows-targets->windows_x86_64_gnullvm           0.48.5   Removed  Removed  Normal       x86_64-pc-windows-gnullvm
windows-targets->windows_x86_64_msvc              0.48.5   0.52.4   0.52.4   Normal       cfg(all(target_arch = "x86_64", target_env = "msvc", not(windows_raw_dylib)))
windows-targets->windows_x86_64_msvc              0.48.5   Removed  Removed  Normal       cfg(all(target_arch = "x86_64", target_env = "msvc", not(windows_raw_dylib)))
```