### PR TITLE
Minor: drop std where possible (use core).

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,10 +4,10 @@ extern crate criterion;
 extern crate delaunator;
 extern crate rand;
 
+use core::iter::repeat_with;
 use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration};
 use delaunator::{triangulate, Point};
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::iter::repeat_with;
 
 const COUNTS: &[usize] = &[100, 1000, 10_000, 100_000];
 

--- a/examples/triangulate.rs
+++ b/examples/triangulate.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat_with;
+use core::iter::repeat_with;
 
 const N: usize = 1_000_000;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,5 @@
+use core::f64;
 use delaunator::{triangulate, Point, Triangulation, EMPTY, EPSILON};
-use std::f64;
 use std::fs::File;
 
 macro_rules! test_fixture {


### PR DESCRIPTION
This is a small point, there are no functional changes.

A criticism of the STD library is that it is inflated -- some things  don't absolutely need to be in it. The process of cleaning it up has started .. and some functions are being moved to core

for example 

```rust
-use std::iter::repeat_with;
+use core::iter::repeat_with;
```



 
