### PR TITLE
std::f64 should not have been converted to core::f64.

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,5 @@
-use core::f64;
 use delaunator::{triangulate, Point, Triangulation, EMPTY, EPSILON};
+use std::f64;
 use std::fs::File;
 
 macro_rules! test_fixture {


### PR DESCRIPTION
I have made a mistake, I want to unwind, sorry for the churn.

I was correct to use "core::iter::repeat_with" but core::f64 has recently been made std specific

This partially undoes

```
commit 48b9ffb9f8ca6207eee8a81565cbc1199187dd6d (HEAD -> master, origin/master, origin/HEAD)
Author: martin frances <martinfrances107@hotmail.com>
Date:   Thu Feb 29 08:02:21 2024 +0000

    Minor: drop std where possible (use core). (#36)
```

and partially restores

```
commit 2065e4a8f00a72d5a88cd274187695497ee8a5be
Author: SasakiSaki <192608617@qq.com>
Date:   Wed Apr 19 01:28:10 2023 +0800

    `core::f64` has been deprecated (#29)
```