### PR TITLE
Minor: Bumped serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ robust = "1.0.0"
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
-serde_json = "1.0.94"
+serde_json = "1.0.132"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
I love this project ... and for things I rely on every day  I try and do periodic maintence 

Nothing special - justing running cargo clippy, cargo outdated, cargo machete etc...
[ More clippy warnings are slowly being developed. ]

This came up today 

-serde_json = "1.0.94"
+serde_json = "1.0.132"

This is a dev dependecy ... so not a change in production code.

I am not sure I trust the result of benchmarking
but on face value the actual benchmarking test time has improved.

```bash
Finished `bench` profile [optimized] target(s) in 59.26s
     Running benches/bench.rs (target/release/deps/bench-38e507cb5ec35a67)
triangulate/100         time:   [21.323 µs 22.019 µs 22.801 µs]
                        change: [-34.289% -30.835% -26.900%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
triangulate/1000        time:   [442.91 µs 456.44 µs 470.64 µs]
                        change: [-28.916% -24.412% -19.495%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
triangulate/10000       time:   [4.3351 ms 4.4409 ms 4.5514 ms]
                        change: [-32.887% -29.992% -26.908%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking triangulate/100000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, or reduce sample count to 60.
triangulate/100000      time:   [77.960 ms 80.784 ms 83.744 ms]
                        change: [-27.383% -24.404% -21.255%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```