### PR TITLE
fix: use a stable sort in sortf function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate std;
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::{cmp::Ordering, fmt};
+use core::fmt;
 use robust::orient2d;
 
 /// Near-duplicate points (where both `x` and `y` only differ within this value)
@@ -465,7 +465,7 @@ fn find_seed_triangle(points: &[Point]) -> Option<(usize, usize, usize)> {
 }
 
 fn sortf(f: &mut [(usize, f64)]) {
-    f.sort_unstable_by(|&(_, da), &(_, db)| da.partial_cmp(&db).unwrap_or(Ordering::Equal));
+    f.sort_by(|(_, da), (_, db)| da.total_cmp(db));
 }
 
 /// Order collinear points by dx (or dy if all x are identical) and return the list as a hull


### PR DESCRIPTION
I ran into an issue upgrading Rust 1.80 to 1.82 which broke some of our testing.

I tracked the issue down to a change in the output of triangualate, driven by not using a stable sort.

By using a stable sorting algorithm, the output of the triangulate function will be stable across Rust versions.