### PR TITLE
Added traits for point, number, and functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 rust-version = "1.60.0"
 
 [dependencies]
-robust = "1.2.0"
+robust = { version = "1.2.0", features = ["no_std"], optional = true }
 
 [dev-dependencies]
 criterion = "0.7.0"
@@ -22,7 +22,8 @@ serde = "1.0.228"
 serde_json = "1.0.132"
 
 [features]
-default = ["std"]
+default = ["std", "robust"]
+robust = ["dep:robust"]
 std = []
 
 [lib]
@@ -31,11 +32,14 @@ bench = false
 [[bench]]
 name = "bench"
 harness = false
+required-features = ["robust"]
 
 [[example]]
 name = "triangulate"
 path = "examples/triangulate.rs"
+required-features = ["robust"]
 
 [[example]]
 name = "svg"
 path = "examples/svg.rs"
+required-features = ["robust"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
 rust-version = "1.60.0"
 
 [dependencies]
-robust = { version = "1.2.0", features = ["no_std"], optional = true }
+robust = { version = "1.2.0", features = ["no_std"] }
 
 [dev-dependencies]
 criterion = "0.7.0"
@@ -22,8 +22,7 @@ serde = "1.0.228"
 serde_json = "1.0.132"
 
 [features]
-default = ["std", "robust"]
-robust = ["dep:robust"]
+default = ["std"]
 std = []
 
 [lib]
@@ -32,14 +31,11 @@ bench = false
 [[bench]]
 name = "bench"
 harness = false
-required-features = ["robust"]
 
 [[example]]
 name = "triangulate"
 path = "examples/triangulate.rs"
-required-features = ["robust"]
 
 [[example]]
 name = "svg"
 path = "examples/svg.rs"
-required-features = ["robust"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delaunator"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2018"
 description = "A very fast 2D Delaunay triangulation library."
 documentation = "https://docs.rs/delaunator"
@@ -10,13 +10,15 @@ license = "ISC"
 categories = ["algorithms", "data-structures"]
 keywords = ["delaunay", "triangulation", "tessellation", "spatial", "geometry"]
 authors = ["Vladimir Agafonkin <agafonkin@gmail.com>"]
+rust-version = "1.60.0"
 
 [dependencies]
 robust = "1.2.0"
 
 [dev-dependencies]
-criterion = "0.6.0"
+criterion = "0.7.0"
 rand = "0.9.2"
+serde = "1.0.228"
 serde_json = "1.0.132"
 
 [features]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,7 +6,7 @@ extern crate rand;
 
 use core::iter::repeat_with;
 use criterion::{AxisScale, BenchmarkId, Criterion, PlotConfiguration};
-use delaunator::{triangulate, Point};
+use delaunator::triangulate;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 const COUNTS: &[usize] = &[100, 1000, 10_000, 100_000];
@@ -14,8 +14,7 @@ const COUNTS: &[usize] = &[100, 1000, 10_000, 100_000];
 fn bench(c: &mut Criterion) {
     let mut rng: StdRng = StdRng::seed_from_u64(123);
 
-    let all_points: Vec<_> = repeat_with(|| rng.random())
-        .map(|(x, y)| Point { x, y })
+    let all_points: Vec<(f64, f64)> = repeat_with(|| rng.random())
         .take(*COUNTS.last().unwrap())
         .collect();
 

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -15,10 +15,7 @@ fn main() -> std::io::Result<()> {
     let default_path = "tests/fixtures/robust4.json".to_string();
     let args = env::args().collect::<Vec<String>>();
     let path = args.get(1).unwrap_or(&default_path);
-    let points: Vec<Point> = serde_json::from_reader::<_, Vec<(f64, f64)>>(File::open(path)?)?
-        .iter()
-        .map(|p| Point { x: p.0, y: p.1 })
-        .collect();
+    let points = serde_json::from_reader::<_, Vec<(f64, f64)>>(File::open(path)?)?;
 
     // triangulate and scale points for display
     let triangulation = delaunator::triangulate(&points);
@@ -41,7 +38,7 @@ fn main() -> std::io::Result<()> {
                 let start = &points[triangulation.triangles[e]];
                 let end = &points[triangulation.triangles[next_halfedge(e)]];
                 let color = if triangulation.halfedges[e] == EMPTY { HULL_COLOR } else { LINE_COLOR };
-                acc + &format!(r#"<line x1="{x0}" y1="{y0}" x2="{x1}" y2="{y1}" style="stroke:{color};stroke-width:{width}" />"#, x0 = start.x, y0 = start.y, x1=end.x, y1=end.y, width = LINE_WIDTH, color = color)
+                acc + &format!(r#"<line x1="{x0}" y1="{y0}" x2="{x1}" y2="{y1}" style="stroke:{color};stroke-width:{width}" />"#, x0 = start.x(), y0 = start.y(), x1=end.x(), y1=end.y(), width = LINE_WIDTH, color = color)
             } else {
                 acc
             }
@@ -52,12 +49,12 @@ fn main() -> std::io::Result<()> {
 
 /// Finds the center point and farthest point from it, then generates a new vector of
 /// scaled and offset points such that they fit between [0..SIZE]
-fn center_and_scale(points: &Vec<Point>, t: &Triangulation) -> Vec<Point> {
-    let center = &points[*t.triangles.get(0).unwrap_or(&0)];
+fn center_and_scale<P: Point<Number = f64>>(points: &[P], t: &Triangulation) -> Vec<P> {
+    let center = &points[*t.triangles.first().unwrap_or(&0)];
     let farthest_distance = points
         .iter()
         .map(|p| {
-            let (x, y) = (center.x - p.x, center.y - p.y);
+            let (x, y) = (center.x() - p.x(), center.y() - p.y());
             x * x + y * y
         })
         .reduce(f64::max)
@@ -65,19 +62,16 @@ fn center_and_scale(points: &Vec<Point>, t: &Triangulation) -> Vec<Point> {
         .sqrt();
     let scale = CANVAS_SIZE / (farthest_distance * 2.0);
     let offset = (
-        (CANVAS_SIZE / 2.0) - (scale * center.x),
-        (CANVAS_SIZE / 2.0) - (scale * center.y),
+        (CANVAS_SIZE / 2.0) - (scale * center.x()),
+        (CANVAS_SIZE / 2.0) - (scale * center.y()),
     );
     points
         .iter()
-        .map(|p| Point {
-            x: scale * p.x + offset.0,
-            y: scale * p.y + offset.1,
-        })
+        .map(|p| P::new_point(scale * p.x() + offset.0, scale * p.y() + offset.1))
         .collect()
 }
 
-fn render_point(points: &[Point], triangulation: &Triangulation) -> String {
+fn render_point(points: &[impl Point<Number = f64>], triangulation: &Triangulation) -> String {
     let mut circles = points
         .iter()
         .enumerate()
@@ -89,8 +83,8 @@ fn render_point(points: &[Point], triangulation: &Triangulation) -> String {
             };
             acc + &format!(
                 r#"<circle cx="{x}" cy="{y}" r="{size}" fill="{color}"/>"#,
-                x = p.x,
-                y = p.y,
+                x = p.x(),
+                y = p.y(),
                 size = POINT_SIZE,
                 color = color
             )
@@ -102,8 +96,8 @@ fn render_point(points: &[Point], triangulation: &Triangulation) -> String {
             acc + &format!(
                 r#"<text x="{x}" y="{y}" font-size="20" fill="black">{i}</text>"#,
                 i = i,
-                x = p.x + 10.,
-                y = p.y - 5.
+                x = p.x() + 10.,
+                y = p.y() - 5.
             )
         })
     }

--- a/examples/triangulate.rs
+++ b/examples/triangulate.rs
@@ -3,10 +3,7 @@ use core::iter::repeat_with;
 const N: usize = 1_000_000;
 
 fn main() {
-    let points: Vec<_> = repeat_with(rand::random)
-        .map(|(x, y)| delaunator::Point { x, y })
-        .take(N)
-        .collect();
+    let points: Vec<(f64, f64)> = repeat_with(rand::random).take(N).collect();
 
     let now = std::time::Instant::now();
     let result = delaunator::triangulate(&points);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@ A port of [Delaunator](https://github.com/mapbox/delaunator).
 # Example
 
 ```rust
-use delaunator::{Point, triangulate};
+use delaunator::{ triangulate};
 
 let points = vec![
-    Point { x: 0., y: 0. },
-    Point { x: 1., y: 0. },
-    Point { x: 1., y: 1. },
-    Point { x: 0., y: 1. },
+    (0., 0.),
+    (1., 0.),
+    (1., 1.),
+    (0., 1.),
 ];
 
 let result = triangulate(&points);
@@ -28,119 +28,11 @@ extern crate std;
 #[macro_use]
 extern crate alloc;
 
+pub mod traits;
+pub use traits::*;
+
 use alloc::vec::Vec;
-use core::{cmp::Ordering, fmt};
-use robust::orient2d;
-
-/// Near-duplicate points (where both `x` and `y` only differ within this value)
-/// will not be included in the triangulation for robustness.
-pub const EPSILON: f64 = f64::EPSILON * 2.0;
-
-/// Represents a 2D point in the input vector.
-#[derive(Clone, PartialEq, Default)]
-pub struct Point {
-    pub x: f64,
-    pub y: f64,
-}
-
-impl fmt::Debug for Point {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "[{}, {}]", self.x, self.y)
-    }
-}
-
-impl From<&Point> for robust::Coord<f64> {
-    fn from(p: &Point) -> robust::Coord<f64> {
-        robust::Coord::<f64> { x: p.x, y: p.y }
-    }
-}
-
-impl From<(f64, f64)> for Point {
-    fn from((x, y): (f64, f64)) -> Self {
-        Point { x, y }
-    }
-}
-
-impl From<[f64; 2]> for Point {
-    fn from([x, y]: [f64; 2]) -> Self {
-        Point { x, y }
-    }
-}
-
-impl From<Point> for (f64, f64) {
-    fn from(pt: Point) -> Self {
-        (pt.x, pt.y)
-    }
-}
-
-impl From<Point> for [f64; 2] {
-    fn from(pt: Point) -> Self {
-        [pt.x, pt.y]
-    }
-}
-
-impl Point {
-    fn dist2(&self, p: &Self) -> f64 {
-        let dx = self.x - p.x;
-        let dy = self.y - p.y;
-        dx * dx + dy * dy
-    }
-
-    /// Returns a **negative** value if ```self```, ```q``` and ```r``` occur in counterclockwise order (```r``` is to the left of the directed line ```self``` --> ```q```)
-    /// Returns a **positive** value if they occur in clockwise order(```r``` is to the right of the directed line ```self``` --> ```q```)
-    /// Returns zero is they are collinear
-    fn orient(&self, q: &Self, r: &Self) -> f64 {
-        // robust-rs orients Y-axis upwards, our convention is Y downwards. This means that the interpretation of the result must be flipped
-        orient2d(self.into(), q.into(), r.into())
-    }
-
-    fn circumdelta(&self, b: &Self, c: &Self) -> (f64, f64) {
-        let dx = b.x - self.x;
-        let dy = b.y - self.y;
-        let ex = c.x - self.x;
-        let ey = c.y - self.y;
-
-        let bl = dx * dx + dy * dy;
-        let cl = ex * ex + ey * ey;
-        let d = 0.5 / (dx * ey - dy * ex);
-
-        let x = (ey * bl - dy * cl) * d;
-        let y = (dx * cl - ex * bl) * d;
-        (x, y)
-    }
-
-    fn circumradius2(&self, b: &Self, c: &Self) -> f64 {
-        let (x, y) = self.circumdelta(b, c);
-        x * x + y * y
-    }
-
-    fn circumcenter(&self, b: &Self, c: &Self) -> Self {
-        let (x, y) = self.circumdelta(b, c);
-        Self {
-            x: self.x + x,
-            y: self.y + y,
-        }
-    }
-
-    fn in_circle(&self, b: &Self, c: &Self, p: &Self) -> bool {
-        let dx = self.x - p.x;
-        let dy = self.y - p.y;
-        let ex = b.x - p.x;
-        let ey = b.y - p.y;
-        let fx = c.x - p.x;
-        let fy = c.y - p.y;
-
-        let ap = dx * dx + dy * dy;
-        let bp = ex * ex + ey * ey;
-        let cp = fx * fx + fy * fy;
-
-        dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx) < 0.0
-    }
-
-    fn nearly_equals(&self, p: &Self) -> bool {
-        f64_abs(self.x - p.x) <= EPSILON && f64_abs(self.y - p.y) <= EPSILON
-    }
-}
+use std::cmp::Ordering;
 
 /// Represents the area outside of the triangulation.
 /// Halfedges on the convex hull (which don't have an adjacent halfedge)
@@ -236,7 +128,13 @@ impl Triangulation {
         t
     }
 
-    fn legalize(&mut self, a: usize, points: &[Point], hull: &mut Hull) -> usize {
+    fn legalize<F: GlobalFunctions>(
+        &mut self,
+        a: usize,
+        points: &[F::Point],
+        hull: &mut Hull<F::Point>,
+        functions: &F,
+    ) -> usize {
         let b = self.halfedges[a];
 
         // if the pair of triangles doesn't satisfy the Delaunay condition
@@ -268,7 +166,7 @@ impl Triangulation {
         let pl = self.triangles[al];
         let p1 = self.triangles[bl];
 
-        let illegal = points[p0].in_circle(&points[pr], &points[pl], &points[p1]);
+        let illegal = functions.in_circle(&points[p0], &points[pr], &points[pl], &points[p1]);
         if illegal {
             self.triangles[a] = p1;
             self.triangles[b] = p0;
@@ -307,26 +205,33 @@ impl Triangulation {
 
             let br = next_halfedge(b);
 
-            self.legalize(a, points, hull);
-            return self.legalize(br, points, hull);
+            self.legalize(a, points, hull, functions);
+            return self.legalize(br, points, hull, functions);
         }
         ar
     }
 }
 
 // data structure for tracking the edges of the advancing convex hull
-struct Hull {
+struct Hull<P: Point> {
     prev: Vec<usize>,
     next: Vec<usize>,
     tri: Vec<usize>,
     hash: Vec<usize>,
     start: usize,
-    center: Point,
+    center: P,
 }
 
-impl Hull {
-    fn new(n: usize, center: Point, i0: usize, i1: usize, i2: usize, points: &[Point]) -> Self {
-        let hash_len = f64_sqrt(n as f64) as usize;
+impl<P: Point> Hull<P> {
+    fn new(
+        n: usize,
+        center: P,
+        i0: usize,
+        i1: usize,
+        i2: usize,
+        points: &[impl Point<Number = P::Number>],
+    ) -> Self {
+        let hash_len = (n as f64).sqrt() as usize;
 
         let mut hull = Self {
             prev: vec![0; n],            // edge to prev edge
@@ -355,23 +260,35 @@ impl Hull {
         hull
     }
 
-    fn hash_key(&self, p: &Point) -> usize {
-        let dx = p.x - self.center.x;
-        let dy = p.y - self.center.y;
+    fn hash_key(&self, p: &impl Point<Number = P::Number>) -> usize {
+        let dx = p.x() - self.center.x();
+        let dy = p.y() - self.center.y();
 
-        let p = dx / (f64_abs(dx) + f64_abs(dy));
-        let a = (if dy > 0.0 { 3.0 - p } else { 1.0 + p }) / 4.0; // [0..1]
+        let p = dx / ((dx).abs() + (dy).abs());
+        let a = (if dy > P::Number::ZERO {
+            P::Number::THREE - p
+        } else {
+            P::Number::ONE + p
+        }) / P::Number::FOUR; // [0..1]
 
         let len = self.hash.len();
-        (f64_floor((len as f64) * a) as usize) % len
+        ((P::Number::from_usize_truncate(len)) * a)
+            .floor()
+            .into_usize_truncate()
+            % len
     }
 
-    fn hash_edge(&mut self, p: &Point, i: usize) {
+    fn hash_edge(&mut self, p: &impl Point<Number = P::Number>, i: usize) {
         let key = self.hash_key(p);
         self.hash[key] = i;
     }
 
-    fn find_visible_edge(&self, p: &Point, points: &[Point]) -> (usize, bool) {
+    fn find_visible_edge<F: GlobalFunctions<Point = P>>(
+        &self,
+        p: &F::Point,
+        points: &[F::Point],
+        functions: &F,
+    ) -> (usize, bool) {
         let mut start: usize = 0;
         let key = self.hash_key(p);
         let len = self.hash.len();
@@ -384,7 +301,10 @@ impl Hull {
         start = self.prev[start];
         let mut e = start;
 
-        while p.orient(&points[e], &points[self.next[e]]) <= 0. {
+        while matches!(
+            functions.orient(p, &points[e], &points[self.next[e]]),
+            Orient::Collinear | Orient::CounterClockwise
+        ) {
             e = self.next[e];
             if e == start {
                 return (EMPTY, false);
@@ -394,99 +314,115 @@ impl Hull {
     }
 }
 
-fn calc_bbox_center(points: &[Point]) -> Point {
-    let mut min_x = f64::INFINITY;
-    let mut min_y = f64::INFINITY;
-    let mut max_x = f64::NEG_INFINITY;
-    let mut max_y = f64::NEG_INFINITY;
-    for p in points.iter() {
-        min_x = min_x.min(p.x);
-        min_y = min_y.min(p.y);
-        max_x = max_x.max(p.x);
-        max_y = max_y.max(p.y);
+fn calc_bbox_center<'a, P: Point>(
+    points: impl IntoIterator<Item = &'a (impl Point<Number = P::Number> + 'a)>,
+) -> P {
+    let mut min_x = P::Number::INFINITY;
+    let mut min_y = P::Number::INFINITY;
+    let mut max_x = P::Number::NEG_INFINITY;
+    let mut max_y = P::Number::NEG_INFINITY;
+    for p in points.into_iter() {
+        min_x = min_x.min(p.x());
+        min_y = min_y.min(p.y());
+        max_x = max_x.max(p.x());
+        max_y = max_y.max(p.y());
     }
-    Point {
-        x: (min_x + max_x) / 2.0,
-        y: (min_y + max_y) / 2.0,
-    }
+    P::new_point(
+        (min_x + max_x) / P::Number::TWO,
+        (min_y + max_y) / P::Number::TWO,
+    )
 }
 
-fn find_closest_point(points: &[Point], p0: &Point) -> Option<usize> {
-    let mut min_dist = f64::INFINITY;
+fn find_closest_point<'a, N: Number, P: Point<Number = N> + 'a>(
+    points: impl IntoIterator<Item = &'a P>,
+    p0: &P,
+    functions: &impl GlobalFunctions<Point = P, Number = N>,
+) -> Option<usize> {
+    let mut min_dist = P::Number::INFINITY;
     let mut k: usize = 0;
-    for (i, p) in points.iter().enumerate() {
-        let d = p0.dist2(p);
-        if d > 0.0 && d < min_dist {
+    for (i, p) in points.into_iter().enumerate() {
+        let d = functions.dist2(p0, p);
+        if d > P::Number::ZERO && d < min_dist {
             k = i;
             min_dist = d;
         }
     }
-    if min_dist == f64::INFINITY {
+    if min_dist == N::INFINITY {
         None
     } else {
         Some(k)
     }
 }
 
-fn find_seed_triangle(points: &[Point]) -> Option<(usize, usize, usize)> {
+fn find_seed_triangle<N: Number, P: Point<Number = N>>(
+    points: &[P],
+    functions: &impl GlobalFunctions<Point = P, Number = N>,
+) -> Option<(usize, usize, usize)> {
     // pick a seed point close to the center
-    let bbox_center = calc_bbox_center(points);
-    let i0 = find_closest_point(points, &bbox_center)?;
+    let bbox_center: P = calc_bbox_center(points);
+    let i0 = find_closest_point(points, &bbox_center, functions)?;
     let p0 = &points[i0];
 
     // find the point closest to the seed
-    let i1 = find_closest_point(points, p0)?;
+    let i1 = find_closest_point(points, p0, functions)?;
     let p1 = &points[i1];
 
     // find the third point which forms the smallest circumcircle with the first two
-    let mut min_radius = f64::INFINITY;
+    let mut min_radius = P::Number::INFINITY;
     let mut i2: usize = 0;
     for (i, p) in points.iter().enumerate() {
         if i == i0 || i == i1 {
             continue;
         }
-        let r = p0.circumradius2(p1, p);
+        let r = functions.circumradius2(p0, p1, p);
         if r < min_radius {
             i2 = i;
             min_radius = r;
         }
     }
 
-    if min_radius == f64::INFINITY {
+    if min_radius == P::Number::INFINITY {
         None
     } else {
         // swap the order of the seed points for counter-clockwise orientation
-        Some(if p0.orient(p1, &points[i2]) > 0. {
-            (i0, i2, i1)
-        } else {
-            (i0, i1, i2)
-        })
+        Some(
+            if functions.orient(p0, p1, &points[i2]) == Orient::Clockwise {
+                (i0, i2, i1)
+            } else {
+                (i0, i1, i2)
+            },
+        )
     }
 }
 
-fn sortf(f: &mut [(usize, f64)]) {
-    f.sort_unstable_by(|&(_, da), &(_, db)| da.partial_cmp(&db).unwrap_or(Ordering::Equal));
-}
-
 /// Order collinear points by dx (or dy if all x are identical) and return the list as a hull
-fn handle_collinear_points(points: &[Point]) -> Triangulation {
-    let Point { x, y } = points.first().cloned().unwrap_or_default();
+fn handle_collinear_points<P: Point>(
+    points: &[P],
+    functions: &impl GlobalFunctions<Point = P>,
+) -> Triangulation {
+    let (x, y) = points
+        .first()
+        .cloned()
+        .map(|p| (p.x(), p.y()))
+        .unwrap_or((P::Number::ZERO, P::Number::ZERO));
 
     let mut dist: Vec<_> = points
         .iter()
         .enumerate()
         .map(|(i, p)| {
-            let mut d = p.x - x;
-            if d == 0.0 {
-                d = p.y - y;
+            let mut d = p.x() - x;
+            if d == P::Number::ZERO {
+                d = p.y() - y;
             }
             (i, d)
         })
         .collect();
-    sortf(&mut dist);
+    functions.sort_slice_by(&mut dist, |&(_, da), &(_, db)| {
+        da.partial_cmp(&db).unwrap_or(Ordering::Equal)
+    });
 
     let mut triangulation = Triangulation::new(0);
-    let mut d0 = f64::NEG_INFINITY;
+    let mut d0 = P::Number::NEG_INFINITY;
     for (i, distance) in dist {
         if distance > d0 {
             triangulation.hull.push(i);
@@ -500,16 +436,31 @@ fn handle_collinear_points(points: &[Point]) -> Triangulation {
 /// Triangulate a set of 2D points.
 /// Returns the triangulation for the input points.
 /// For the degenerated case when all points are collinear, returns an empty triangulation where all points are in the hull.
-pub fn triangulate(points: &[Point]) -> Triangulation {
-    let seed_triangle = find_seed_triangle(points);
+pub fn triangulate<P: Point>(points: &[P]) -> Triangulation
+where
+    P::Number: Into<f64>,
+{
+    triangulate_with_functions(points, &DefaultGlobalFunctions::<P>::const_new())
+}
+
+/// Triangulate a set of 2D points.
+/// Returns the triangulation for the input points.
+/// For the degenerated case when all points are collinear, returns an empty triangulation where all points are in the hull.
+///
+/// Allows specifying custom functions to override the default behavior or optimize for specific use cases.
+pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
+    points: &[P],
+    functions: &impl GlobalFunctions<Point = P, Number = N>,
+) -> Triangulation {
+    let seed_triangle = find_seed_triangle(points, functions);
     if seed_triangle.is_none() {
-        return handle_collinear_points(points);
+        return handle_collinear_points(points, functions);
     }
 
     let n = points.len();
     let (i0, i1, i2) =
         seed_triangle.expect("At this stage, points are guaranteed to yeild a seed triangle");
-    let center = points[i0].circumcenter(&points[i1], &points[i2]);
+    let center = functions.circumcenter(&points[i0], &points[i1], &points[i2]);
 
     let mut triangulation = Triangulation::new(n);
     triangulation.add_triangle(i0, i1, i2, EMPTY, EMPTY, EMPTY);
@@ -518,10 +469,12 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
     let mut dists: Vec<_> = points
         .iter()
         .enumerate()
-        .map(|(i, point)| (i, center.dist2(point)))
+        .map(|(i, point)| (i, functions.dist2(&center, point)))
         .collect();
 
-    sortf(&mut dists);
+    functions.sort_slice_by(&mut dists, |&(_, da), &(_, db)| {
+        da.partial_cmp(&db).unwrap_or(Ordering::Equal)
+    });
 
     let mut hull = Hull::new(n, center, i0, i1, i2, points);
 
@@ -529,7 +482,7 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
         let p = &points[i];
 
         // skip near-duplicates
-        if k > 0 && p.nearly_equals(&points[dists[k - 1].0]) {
+        if k > 0 && functions.nearly_equals(p, &points[dists[k - 1].0]) {
             continue;
         }
         // skip seed triangle points
@@ -538,7 +491,7 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
         }
 
         // find a visible edge on the convex hull using edge hash
-        let (mut e, walk_back) = hull.find_visible_edge(p, points);
+        let (mut e, walk_back) = hull.find_visible_edge(p, points, functions);
         if e == EMPTY {
             continue; // likely a near-duplicate point; skip it
         }
@@ -547,18 +500,21 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
         let t = triangulation.add_triangle(e, i, hull.next[e], EMPTY, EMPTY, hull.tri[e]);
 
         // recursively flip triangles from the point until they satisfy the Delaunay condition
-        hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull);
+        hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull, functions);
         hull.tri[e] = t; // keep track of boundary triangles on the hull
 
         // walk forward through the hull, adding more triangles and flipping recursively
         let mut n = hull.next[e];
         loop {
             let q = hull.next[n];
-            if p.orient(&points[n], &points[q]) <= 0. {
+            if matches!(
+                functions.orient(p, &points[n], &points[q]),
+                Orient::Collinear | Orient::CounterClockwise
+            ) {
                 break;
             }
             let t = triangulation.add_triangle(n, i, q, hull.tri[i], EMPTY, hull.tri[n]);
-            hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull);
+            hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull, functions);
             hull.next[n] = EMPTY; // mark as removed
             n = q;
         }
@@ -567,11 +523,14 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
         if walk_back {
             loop {
                 let q = hull.prev[e];
-                if p.orient(&points[q], &points[e]) <= 0. {
+                if matches!(
+                    functions.orient(p, &points[q], &points[e]),
+                    Orient::Collinear | Orient::CounterClockwise
+                ) {
                     break;
                 }
                 let t = triangulation.add_triangle(q, i, e, EMPTY, hull.tri[e], hull.tri[q]);
-                triangulation.legalize(t + 2, points, &mut hull);
+                triangulation.legalize(t + 2, points, &mut hull, functions);
                 hull.tri[q] = t;
                 hull.next[e] = EMPTY; // mark as removed
                 e = q;
@@ -604,56 +563,4 @@ pub fn triangulate(points: &[Point]) -> Triangulation {
     triangulation.halfedges.shrink_to_fit();
 
     triangulation
-}
-
-#[cfg(feature = "std")]
-#[inline]
-fn f64_abs(f: f64) -> f64 {
-    f.abs()
-}
-
-#[cfg(not(feature = "std"))]
-#[inline]
-fn f64_abs(f: f64) -> f64 {
-    const SIGN_BIT: u64 = 1 << 63;
-    f64::from_bits(f64::to_bits(f) & !SIGN_BIT)
-}
-
-#[cfg(feature = "std")]
-#[inline]
-fn f64_floor(f: f64) -> f64 {
-    f.floor()
-}
-
-#[cfg(not(feature = "std"))]
-#[inline]
-fn f64_floor(f: f64) -> f64 {
-    let mut res = (f as i64) as f64;
-    if res > f {
-        res -= 1.0;
-    }
-    res as f64
-}
-
-#[cfg(feature = "std")]
-#[inline]
-fn f64_sqrt(f: f64) -> f64 {
-    f.sqrt()
-}
-
-#[cfg(not(feature = "std"))]
-#[inline]
-fn f64_sqrt(f: f64) -> f64 {
-    if f < 2.0 {
-        return f;
-    };
-
-    let sc = f64_sqrt(f / 4.0) * 2.0;
-    let lc = sc + 1.0;
-
-    if lc * lc > f {
-        sc
-    } else {
-        lc
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod traits;
 pub use traits::*;
 
 use alloc::vec::Vec;
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 /// Represents the area outside of the triangulation.
 /// Halfedges on the convex hull (which don't have an adjacent halfedge)
@@ -436,6 +436,7 @@ fn handle_collinear_points<P: Point>(
 /// Triangulate a set of 2D points.
 /// Returns the triangulation for the input points.
 /// For the degenerated case when all points are collinear, returns an empty triangulation where all points are in the hull.
+#[cfg(feature = "robust")]
 pub fn triangulate<P: Point>(points: &[P]) -> Triangulation
 where
     P::Number: Into<f64>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,15 @@ extern crate std;
 #[macro_use]
 extern crate alloc;
 
+pub mod point_ext;
 pub mod traits;
+
 pub use traits::*;
 
 use alloc::vec::Vec;
 use core::cmp::Ordering;
+
+use crate::point_ext::{Orient, PointExt};
 
 /// Represents the area outside of the triangulation.
 /// Halfedges on the convex hull (which don't have an adjacent halfedge)
@@ -128,13 +132,7 @@ impl Triangulation {
         t
     }
 
-    fn legalize<F: GlobalFunctions>(
-        &mut self,
-        a: usize,
-        points: &[F::Point],
-        hull: &mut Hull<F::Point>,
-        functions: &F,
-    ) -> usize {
+    fn legalize<P: Point>(&mut self, a: usize, points: &[P], hull: &mut Hull<P>) -> usize {
         let b = self.halfedges[a];
 
         // if the pair of triangles doesn't satisfy the Delaunay condition
@@ -166,7 +164,7 @@ impl Triangulation {
         let pl = self.triangles[al];
         let p1 = self.triangles[bl];
 
-        let illegal = functions.in_circle(&points[p0], &points[pr], &points[pl], &points[p1]);
+        let illegal = points[p0].in_circle(&points[pr], &points[pl], &points[p1]);
         if illegal {
             self.triangles[a] = p1;
             self.triangles[b] = p0;
@@ -205,8 +203,8 @@ impl Triangulation {
 
             let br = next_halfedge(b);
 
-            self.legalize(a, points, hull, functions);
-            return self.legalize(br, points, hull, functions);
+            self.legalize(a, points, hull);
+            return self.legalize(br, points, hull);
         }
         ar
     }
@@ -264,7 +262,7 @@ impl<P: Point> Hull<P> {
         let dx = p.x() - self.center.x();
         let dy = p.y() - self.center.y();
 
-        let p = dx / ((dx).abs() + (dy).abs());
+        let p = dx / (dx.abs() + dy.abs());
         let a = (if dy > P::Number::ZERO {
             P::Number::THREE - p
         } else {
@@ -272,7 +270,7 @@ impl<P: Point> Hull<P> {
         }) / P::Number::FOUR; // [0..1]
 
         let len = self.hash.len();
-        ((P::Number::from_usize_truncate(len)) * a)
+        ((P::Number::from_usize(len)) * a)
             .floor()
             .into_usize_truncate()
             % len
@@ -283,12 +281,7 @@ impl<P: Point> Hull<P> {
         self.hash[key] = i;
     }
 
-    fn find_visible_edge<F: GlobalFunctions<Point = P>>(
-        &self,
-        p: &F::Point,
-        points: &[F::Point],
-        functions: &F,
-    ) -> (usize, bool) {
+    fn find_visible_edge(&self, p: &P, points: &[P]) -> (usize, bool) {
         let mut start: usize = 0;
         let key = self.hash_key(p);
         let len = self.hash.len();
@@ -302,7 +295,7 @@ impl<P: Point> Hull<P> {
         let mut e = start;
 
         while matches!(
-            functions.orient(p, &points[e], &points[self.next[e]]),
+            p.orient(&points[e], &points[self.next[e]]),
             Orient::Collinear | Orient::CounterClockwise
         ) {
             e = self.next[e];
@@ -336,12 +329,11 @@ fn calc_bbox_center<'a, P: Point>(
 fn find_closest_point<'a, N: Number, P: Point<Number = N> + 'a>(
     points: impl IntoIterator<Item = &'a P>,
     p0: &P,
-    functions: &impl GlobalFunctions<Point = P, Number = N>,
 ) -> Option<usize> {
     let mut min_dist = P::Number::INFINITY;
     let mut k: usize = 0;
     for (i, p) in points.into_iter().enumerate() {
-        let d = functions.dist2(p0, p);
+        let d = p0.dist2(p);
         if d > P::Number::ZERO && d < min_dist {
             k = i;
             min_dist = d;
@@ -356,15 +348,14 @@ fn find_closest_point<'a, N: Number, P: Point<Number = N> + 'a>(
 
 fn find_seed_triangle<N: Number, P: Point<Number = N>>(
     points: &[P],
-    functions: &impl GlobalFunctions<Point = P, Number = N>,
 ) -> Option<(usize, usize, usize)> {
     // pick a seed point close to the center
     let bbox_center: P = calc_bbox_center(points);
-    let i0 = find_closest_point(points, &bbox_center, functions)?;
+    let i0 = find_closest_point(points, &bbox_center)?;
     let p0 = &points[i0];
 
     // find the point closest to the seed
-    let i1 = find_closest_point(points, p0, functions)?;
+    let i1 = find_closest_point(points, p0)?;
     let p1 = &points[i1];
 
     // find the third point which forms the smallest circumcircle with the first two
@@ -374,7 +365,7 @@ fn find_seed_triangle<N: Number, P: Point<Number = N>>(
         if i == i0 || i == i1 {
             continue;
         }
-        let r = functions.circumradius2(p0, p1, p);
+        let r = p0.circumradius2(p1, p);
         if r < min_radius {
             i2 = i;
             min_radius = r;
@@ -385,21 +376,16 @@ fn find_seed_triangle<N: Number, P: Point<Number = N>>(
         None
     } else {
         // swap the order of the seed points for counter-clockwise orientation
-        Some(
-            if functions.orient(p0, p1, &points[i2]) == Orient::Clockwise {
-                (i0, i2, i1)
-            } else {
-                (i0, i1, i2)
-            },
-        )
+        Some(if p0.orient(p1, &points[i2]) == Orient::Clockwise {
+            (i0, i2, i1)
+        } else {
+            (i0, i1, i2)
+        })
     }
 }
 
 /// Order collinear points by dx (or dy if all x are identical) and return the list as a hull
-fn handle_collinear_points<P: Point>(
-    points: &[P],
-    functions: &impl GlobalFunctions<Point = P>,
-) -> Triangulation {
+fn handle_collinear_points<P: Point>(points: &[P]) -> Triangulation {
     let (x, y) = points
         .first()
         .cloned()
@@ -417,7 +403,7 @@ fn handle_collinear_points<P: Point>(
             (i, d)
         })
         .collect();
-    functions.sort_slice_by(&mut dist, |&(_, da), &(_, db)| {
+    P::sort_slice_by(&mut dist, |&(_, da), &(_, db)| {
         da.partial_cmp(&db).unwrap_or(Ordering::Equal)
     });
 
@@ -436,32 +422,16 @@ fn handle_collinear_points<P: Point>(
 /// Triangulate a set of 2D points.
 /// Returns the triangulation for the input points.
 /// For the degenerated case when all points are collinear, returns an empty triangulation where all points are in the hull.
-#[cfg(feature = "robust")]
-pub fn triangulate<P: Point>(points: &[P]) -> Triangulation
-where
-    P::Number: Into<f64>,
-{
-    triangulate_with_functions(points, &DefaultGlobalFunctions::<P>::const_new())
-}
-
-/// Triangulate a set of 2D points.
-/// Returns the triangulation for the input points.
-/// For the degenerated case when all points are collinear, returns an empty triangulation where all points are in the hull.
-///
-/// Allows specifying custom functions to override the default behavior or optimize for specific use cases.
-pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
-    points: &[P],
-    functions: &impl GlobalFunctions<Point = P, Number = N>,
-) -> Triangulation {
-    let seed_triangle = find_seed_triangle(points, functions);
+pub fn triangulate<P: Point>(points: &[P]) -> Triangulation {
+    let seed_triangle = find_seed_triangle(points);
     if seed_triangle.is_none() {
-        return handle_collinear_points(points, functions);
+        return handle_collinear_points(points);
     }
 
     let n = points.len();
     let (i0, i1, i2) =
         seed_triangle.expect("At this stage, points are guaranteed to yeild a seed triangle");
-    let center = functions.circumcenter(&points[i0], &points[i1], &points[i2]);
+    let center = points[i0].circumcenter(&points[i1], &points[i2]);
 
     let mut triangulation = Triangulation::new(n);
     triangulation.add_triangle(i0, i1, i2, EMPTY, EMPTY, EMPTY);
@@ -470,20 +440,20 @@ pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
     let mut dists: Vec<_> = points
         .iter()
         .enumerate()
-        .map(|(i, point)| (i, functions.dist2(&center, point)))
+        .map(|(i, point)| (i, center.dist2(point)))
         .collect();
 
-    functions.sort_slice_by(&mut dists, |&(_, da), &(_, db)| {
+    P::sort_slice_by(&mut dists, |&(_, da), &(_, db)| {
         da.partial_cmp(&db).unwrap_or(Ordering::Equal)
     });
 
     let mut hull = Hull::new(n, center, i0, i1, i2, points);
 
     for (k, &(i, _)) in dists.iter().enumerate() {
-        let p = &points[i];
+        let p: &P = &points[i];
 
         // skip near-duplicates
-        if k > 0 && functions.nearly_equals(p, &points[dists[k - 1].0]) {
+        if k > 0 && p.nearly_equals(&points[dists[k - 1].0]) {
             continue;
         }
         // skip seed triangle points
@@ -492,7 +462,7 @@ pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
         }
 
         // find a visible edge on the convex hull using edge hash
-        let (mut e, walk_back) = hull.find_visible_edge(p, points, functions);
+        let (mut e, walk_back) = hull.find_visible_edge(p, points);
         if e == EMPTY {
             continue; // likely a near-duplicate point; skip it
         }
@@ -501,7 +471,7 @@ pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
         let t = triangulation.add_triangle(e, i, hull.next[e], EMPTY, EMPTY, hull.tri[e]);
 
         // recursively flip triangles from the point until they satisfy the Delaunay condition
-        hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull, functions);
+        hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull);
         hull.tri[e] = t; // keep track of boundary triangles on the hull
 
         // walk forward through the hull, adding more triangles and flipping recursively
@@ -509,13 +479,13 @@ pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
         loop {
             let q = hull.next[n];
             if matches!(
-                functions.orient(p, &points[n], &points[q]),
+                p.orient(&points[n], &points[q]),
                 Orient::Collinear | Orient::CounterClockwise
             ) {
                 break;
             }
             let t = triangulation.add_triangle(n, i, q, hull.tri[i], EMPTY, hull.tri[n]);
-            hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull, functions);
+            hull.tri[i] = triangulation.legalize(t + 2, points, &mut hull);
             hull.next[n] = EMPTY; // mark as removed
             n = q;
         }
@@ -525,13 +495,13 @@ pub fn triangulate_with_functions<N: Number, P: Point<Number = N>>(
             loop {
                 let q = hull.prev[e];
                 if matches!(
-                    functions.orient(p, &points[q], &points[e]),
+                    p.orient(&points[q], &points[e]),
                     Orient::Collinear | Orient::CounterClockwise
                 ) {
                     break;
                 }
                 let t = triangulation.add_triangle(q, i, e, EMPTY, hull.tri[e], hull.tri[q]);
-                triangulation.legalize(t + 2, points, &mut hull, functions);
+                triangulation.legalize(t + 2, points, &mut hull);
                 hull.tri[q] = t;
                 hull.next[e] = EMPTY; // mark as removed
                 e = q;

--- a/src/point_ext.rs
+++ b/src/point_ext.rs
@@ -1,0 +1,97 @@
+use core::cmp::Ordering;
+
+use crate::{Number, Point};
+
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum Orient {
+    CounterClockwise,
+    Clockwise,
+    Collinear,
+}
+
+/// Internal trait for additional point functions.
+pub trait PointExt: Point {
+    fn dist2(&self, q: &Self) -> Self::Number;
+    fn orient(&self, q: &Self, r: &Self) -> Orient;
+    fn circumdelta(&self, b: &Self, c: &Self) -> (Self::Number, Self::Number);
+    fn circumradius2(&self, b: &Self, c: &Self) -> Self::Number;
+    fn circumcenter(&self, b: &Self, c: &Self) -> Self;
+    fn in_circle(&self, b: &Self, c: &Self, q: &Self) -> bool;
+    fn nearly_equals(&self, q: &Self) -> bool;
+}
+
+fn into_robust_coord<N: Number>(p: &impl Point<Number = N>) -> robust::Coord<N> {
+    robust::Coord { x: p.x(), y: p.y() }
+}
+
+impl<P: Point> PointExt for P {
+    fn dist2(&self, q: &Self) -> Self::Number {
+        let dx = self.x() - q.x();
+        let dy = self.y() - q.y();
+        dx * dx + dy * dy
+    }
+
+    fn orient(&self, q: &Self, r: &Self) -> Orient {
+        // Returns a **negative** value if ```self```, ```q``` and ```r``` occur in counterclockwise order (```r``` is to the left of the directed line ```self``` --> ```q```)
+        // Returns a **positive** value if they occur in clockwise order(```r``` is to the right of the directed line ```self``` --> ```q```)
+        // Returns zero is they are collinear
+        match robust::orient2d(
+            into_robust_coord(self),
+            into_robust_coord(q),
+            into_robust_coord(r),
+        )
+        .partial_cmp(&0.0)
+        {
+            Some(Ordering::Less) => Orient::CounterClockwise,
+            Some(Ordering::Equal) => Orient::Collinear,
+            Some(Ordering::Greater) => Orient::Clockwise,
+            None => panic!("orient2d returned NaN"),
+        }
+    }
+
+    fn circumdelta(&self, b: &Self, c: &Self) -> (Self::Number, Self::Number) {
+        let dx = b.x() - self.x();
+        let dy = b.y() - self.y();
+        let ex = c.x() - self.x();
+        let ey = c.y() - self.y();
+
+        let bl = dx * dx + dy * dy;
+        let cl = ex * ex + ey * ey;
+        let d = Self::Number::ONE_HALF / (dx * ey - dy * ex);
+
+        let x = (ey * bl - dy * cl) * d;
+        let y = (dx * cl - ex * bl) * d;
+        (x, y)
+    }
+
+    fn circumradius2(&self, b: &Self, c: &Self) -> Self::Number {
+        let (x, y) = self.circumdelta(b, c);
+        x * x + y * y
+    }
+
+    fn circumcenter(&self, b: &Self, c: &Self) -> Self {
+        let (x, y) = self.circumdelta(b, c);
+        Self::new_point(self.x() + x, self.y() + y)
+    }
+
+    fn in_circle(&self, b: &Self, c: &Self, p: &Self) -> bool {
+        let dx = self.x() - p.x();
+        let dy = self.y() - p.y();
+        let ex = b.x() - p.x();
+        let ey = b.y() - p.y();
+        let fx = c.x() - p.x();
+        let fy = c.y() - p.y();
+
+        let ap = dx * dx + dy * dy;
+        let bp = ex * ex + ey * ey;
+        let cp = fx * fx + fy * fy;
+
+        dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx)
+            < Self::Number::ZERO
+    }
+
+    fn nearly_equals(&self, p: &Self) -> bool {
+        (self.x() - p.x()).abs() <= Self::Number::EPSILON
+            && (self.y() - p.y()).abs() <= Self::Number::EPSILON
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,5 @@
 use core::cmp::Ordering;
-use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Sub};
-use robust::orient2d;
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum Orient {
@@ -31,28 +29,35 @@ pub trait GlobalFunctions {
     fn sort_slice_by<T>(&self, s: &mut [T], f: impl FnMut(&T, &T) -> Ordering);
 }
 
+#[cfg(feature = "robust")]
 fn into_robust_coord<N: Number + Into<f64>>(p: &impl Point<Number = N>) -> robust::Coord<N> {
     robust::Coord { x: p.x(), y: p.y() }
 }
 
+#[cfg(feature = "robust")]
 #[derive(Debug)]
-pub struct DefaultGlobalFunctions<P: Point>(PhantomData<P>);
+pub struct DefaultGlobalFunctions<P: Point>(core::marker::PhantomData<P>);
+#[cfg(feature = "robust")]
 impl<P: Point> DefaultGlobalFunctions<P> {
     pub const fn const_new() -> Self {
-        Self(PhantomData)
+        Self(core::marker::PhantomData)
     }
 }
+#[cfg(feature = "robust")]
 impl<P: Point> Copy for DefaultGlobalFunctions<P> {}
+#[cfg(feature = "robust")]
 impl<P: Point> Clone for DefaultGlobalFunctions<P> {
     fn clone(&self) -> Self {
         *self
     }
 }
+#[cfg(feature = "robust")]
 impl<P: Point> Default for DefaultGlobalFunctions<P> {
     fn default() -> Self {
-        Self(PhantomData)
+        Self(core::marker::PhantomData)
     }
 }
+#[cfg(feature = "robust")]
 impl<P: Point> GlobalFunctions for DefaultGlobalFunctions<P>
 where
     P::Number: Into<f64>,
@@ -70,7 +75,7 @@ where
         // Returns a **negative** value if ```self```, ```q``` and ```r``` occur in counterclockwise order (```r``` is to the left of the directed line ```self``` --> ```q```)
         // Returns a **positive** value if they occur in clockwise order(```r``` is to the right of the directed line ```self``` --> ```q```)
         // Returns zero is they are collinear
-        match orient2d(
+        match robust::orient2d(
             into_robust_coord(p),
             into_robust_coord(q),
             into_robust_coord(r),
@@ -201,6 +206,7 @@ pub trait Number:
     fn min(self, other: Self) -> Self;
 }
 
+#[cfg(feature = "robust")]
 impl<N> Point for robust::Coord<N>
 where
     N: Number + Into<f64>,
@@ -291,7 +297,7 @@ impl Number for f64 {
     #[inline]
     fn abs(self) -> Self {
         const SIGN_BIT: u64 = 1 << 63;
-        f64::from_bits(f64::to_bits(f) & !SIGN_BIT)
+        f64::from_bits(f64::to_bits(self) & !SIGN_BIT)
     }
 
     #[cfg(feature = "std")]
@@ -307,7 +313,7 @@ impl Number for f64 {
         if res > self {
             res -= 1.0;
         }
-        res as f64
+        res
     }
 
     #[cfg(feature = "std")]
@@ -392,7 +398,7 @@ impl Number for f32 {
         if res > self {
             res -= 1.0;
         }
-        res as f32
+        res
     }
 
     #[cfg(feature = "std")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,178 +1,48 @@
 use core::cmp::Ordering;
 use core::ops::{Add, Div, Mul, Sub};
 
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum Orient {
-    CounterClockwise,
-    Clockwise,
-    Collinear,
-}
-
-pub trait GlobalFunctions {
-    type Point: Point<Number = Self::Number>;
+/// Trait for types that are 2D points of a given number.
+pub trait Point: Clone {
     type Number: Number;
 
-    fn dist2(&self, p: &Self::Point, q: &Self::Point) -> Self::Number;
-    fn orient(&self, p: &Self::Point, q: &Self::Point, r: &Self::Point) -> Orient;
-    fn circumdelta(
-        &self,
-        p: &Self::Point,
-        b: &Self::Point,
-        c: &Self::Point,
-    ) -> (Self::Number, Self::Number);
-    fn circumradius2(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Number;
-    fn circumcenter(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Point;
-    fn in_circle(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point, q: &Self::Point)
-        -> bool;
-    fn nearly_equals(&self, p: &Self::Point, q: &Self::Point) -> bool;
+    /// Creates a new point with the specified numbers.
+    fn new_point(x: Self::Number, y: Self::Number) -> Self
+    where
+        Self: Sized;
+    /// Returns the `x` coordinate.
+    fn x(&self) -> Self::Number;
+    /// Returns the `y` coordiante.
+    fn y(&self) -> Self::Number;
+
+    /// Creates a new point from another point type.
+    #[inline]
+    fn from_point(p: &impl Point<Number = Self::Number>) -> Self {
+        Self::new_point(p.x(), p.y())
+    }
+    /// Converts `&self` into another point type.
+    #[inline]
+    fn to_point<P: Point<Number = Self::Number>>(&self) -> P {
+        P::from_point(self)
+    }
+    /// Converts `self` into another point type.
+    #[inline]
+    fn into_point<P: Point<Number = Self::Number>>(self) -> P {
+        P::from_point(&self)
+    }
+
     /// Can be overridden to use stable sorting. By default, this runs `slice::sort_unstable_by`.
-    fn sort_slice_by<T>(&self, s: &mut [T], f: impl FnMut(&T, &T) -> Ordering);
-}
-
-#[cfg(feature = "robust")]
-fn into_robust_coord<N: Number + Into<f64>>(p: &impl Point<Number = N>) -> robust::Coord<N> {
-    robust::Coord { x: p.x(), y: p.y() }
-}
-
-#[cfg(feature = "robust")]
-#[derive(Debug)]
-pub struct DefaultGlobalFunctions<P: Point>(core::marker::PhantomData<P>);
-#[cfg(feature = "robust")]
-impl<P: Point> DefaultGlobalFunctions<P> {
-    pub const fn const_new() -> Self {
-        Self(core::marker::PhantomData)
-    }
-}
-#[cfg(feature = "robust")]
-impl<P: Point> Copy for DefaultGlobalFunctions<P> {}
-#[cfg(feature = "robust")]
-impl<P: Point> Clone for DefaultGlobalFunctions<P> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-#[cfg(feature = "robust")]
-impl<P: Point> Default for DefaultGlobalFunctions<P> {
-    fn default() -> Self {
-        Self(core::marker::PhantomData)
-    }
-}
-#[cfg(feature = "robust")]
-impl<P: Point> GlobalFunctions for DefaultGlobalFunctions<P>
-where
-    P::Number: Into<f64>,
-{
-    type Point = P;
-    type Number = P::Number;
-
-    fn dist2(&self, p: &Self::Point, q: &Self::Point) -> Self::Number {
-        let dx = p.x() - q.x();
-        let dy = p.y() - q.y();
-        dx * dx + dy * dy
-    }
-
-    fn orient(&self, p: &Self::Point, q: &Self::Point, r: &Self::Point) -> Orient {
-        // Returns a **negative** value if ```self```, ```q``` and ```r``` occur in counterclockwise order (```r``` is to the left of the directed line ```self``` --> ```q```)
-        // Returns a **positive** value if they occur in clockwise order(```r``` is to the right of the directed line ```self``` --> ```q```)
-        // Returns zero is they are collinear
-        match robust::orient2d(
-            into_robust_coord(p),
-            into_robust_coord(q),
-            into_robust_coord(r),
-        )
-        .partial_cmp(&0.0)
-        {
-            Some(Ordering::Less) => Orient::CounterClockwise,
-            Some(Ordering::Equal) => Orient::Collinear,
-            Some(Ordering::Greater) => Orient::Clockwise,
-            None => panic!("orient2d returned NaN"),
-        }
-    }
-
-    fn circumdelta(
-        &self,
-        p: &Self::Point,
-        b: &Self::Point,
-        c: &Self::Point,
-    ) -> (Self::Number, Self::Number) {
-        let dx = b.x() - p.x();
-        let dy = b.y() - p.y();
-        let ex = c.x() - p.x();
-        let ey = c.y() - p.y();
-
-        let bl = dx * dx + dy * dy;
-        let cl = ex * ex + ey * ey;
-        let d = Self::Number::ONE_HALF / (dx * ey - dy * ex);
-
-        let x = (ey * bl - dy * cl) * d;
-        let y = (dx * cl - ex * bl) * d;
-        (x, y)
-    }
-
-    fn circumradius2(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Number {
-        let (x, y) = self.circumdelta(p, b, c);
-        x * x + y * y
-    }
-
-    fn circumcenter(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Point {
-        let (x, y) = self.circumdelta(p, b, c);
-        Self::Point::new_point(p.x() + x, p.y() + y)
-    }
-
-    fn in_circle(
-        &self,
-        s: &Self::Point,
-        b: &Self::Point,
-        c: &Self::Point,
-        p: &Self::Point,
-    ) -> bool {
-        let dx = s.x() - p.x();
-        let dy = s.y() - p.y();
-        let ex = b.x() - p.x();
-        let ey = b.y() - p.y();
-        let fx = c.x() - p.x();
-        let fy = c.y() - p.y();
-
-        let ap = dx * dx + dy * dy;
-        let bp = ex * ex + ey * ey;
-        let cp = fx * fx + fy * fy;
-
-        dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx)
-            < Self::Number::ZERO
-    }
-
-    fn nearly_equals(&self, s: &Self::Point, p: &Self::Point) -> bool {
-        (s.x() - p.x()).abs() <= Self::Number::EPSILON
-            && (s.y() - p.y()).abs() <= Self::Number::EPSILON
-    }
-
-    fn sort_slice_by<T>(&self, s: &mut [T], f: impl FnMut(&T, &T) -> Ordering) {
+    #[inline]
+    fn sort_slice_by<T>(s: &mut [T], f: impl FnMut(&T, &T) -> Ordering) {
         s.sort_unstable_by(f)
     }
 }
 
-pub trait Point: Clone {
-    type Number: Number;
-
-    fn new_point(x: Self::Number, y: Self::Number) -> Self
-    where
-        Self: Sized;
-    fn x(&self) -> Self::Number;
-    fn y(&self) -> Self::Number;
-
-    fn from_point(p: &impl Point<Number = Self::Number>) -> Self {
-        Self::new_point(p.x(), p.y())
-    }
-    fn to_point<P: Point<Number = Self::Number>>(&self) -> P {
-        P::from_point(self)
-    }
-    fn into_point<P: Point<Number = Self::Number>>(self) -> P {
-        P::from_point(&self)
-    }
-}
-
+/// A number that can be used in a triangulation point.
+///
+/// Implemented by default for `f64` and `f32`.
 pub trait Number:
     Copy
+    + Into<f64>
     + Add<Output = Self>
     + Sub<Output = Self>
     + Mul<Output = Self>
@@ -185,31 +55,53 @@ pub trait Number:
     /// `std` implementations use `f{32,64}::EPSILON * 2.0`
     const EPSILON: Self;
 
+    /// The constant value of `0.`.
     const ZERO: Self;
+    /// The constant value of `0.5`.
     const ONE_HALF: Self;
+    /// The constant value of `1.`.
     const ONE: Self;
+    /// The constant value of `2.`.
     const TWO: Self;
+    /// The constant value of `3.`.
     const THREE: Self;
+    /// The constant value of `4.`.
     const FOUR: Self;
 
+    /// Infinity
+    ///
+    /// std implementations use `f{32,64}::INFINITY`
     const INFINITY: Self;
+    /// Negative Infinity
+    ///
+    /// std implementations use `f{32,64}::NEG_INFINITY`
     const NEG_INFINITY: Self;
 
+    /// The absolute value of this number.
     fn abs(self) -> Self;
+    /// The floor of this number.
     fn floor(self) -> Self;
+    /// The squareroot of this number.
     fn sqrt(self) -> Self;
 
-    fn from_usize_truncate(n: usize) -> Self;
+    /// Converts a `usize` into the nearest value.
+    ///
+    /// std implementations use `n as Self`
+    fn from_usize(n: usize) -> Self;
+    /// Converts `self` into a `usize` by truncating the decimal portion.
+    ///
+    /// std implementations use `self as usize`
     fn into_usize_truncate(self) -> usize;
 
+    /// The maximum of this and another number.
     fn max(self, other: Self) -> Self;
+    /// The minimum of this and another number.
     fn min(self, other: Self) -> Self;
 }
 
-#[cfg(feature = "robust")]
 impl<N> Point for robust::Coord<N>
 where
-    N: Number + Into<f64>,
+    N: Number,
 {
     type Number = N;
 
@@ -340,7 +232,7 @@ impl Number for f64 {
     }
 
     #[inline]
-    fn from_usize_truncate(n: usize) -> Self {
+    fn from_usize(n: usize) -> Self {
         n as Self
     }
 
@@ -425,7 +317,7 @@ impl Number for f32 {
     }
 
     #[inline]
-    fn from_usize_truncate(n: usize) -> Self {
+    fn from_usize(n: usize) -> Self {
         n as Self
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,440 @@
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+use core::ops::{Add, Div, Mul, Sub};
+use robust::orient2d;
+
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum Orient {
+    CounterClockwise,
+    Clockwise,
+    Collinear,
+}
+
+pub trait GlobalFunctions {
+    type Point: Point<Number = Self::Number>;
+    type Number: Number;
+
+    fn dist2(&self, p: &Self::Point, q: &Self::Point) -> Self::Number;
+    fn orient(&self, p: &Self::Point, q: &Self::Point, r: &Self::Point) -> Orient;
+    fn circumdelta(
+        &self,
+        p: &Self::Point,
+        b: &Self::Point,
+        c: &Self::Point,
+    ) -> (Self::Number, Self::Number);
+    fn circumradius2(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Number;
+    fn circumcenter(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Point;
+    fn in_circle(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point, q: &Self::Point)
+        -> bool;
+    fn nearly_equals(&self, p: &Self::Point, q: &Self::Point) -> bool;
+    /// Can be overridden to use stable sorting. By default, this runs `slice::sort_unstable_by`.
+    fn sort_slice_by<T>(&self, s: &mut [T], f: impl FnMut(&T, &T) -> Ordering);
+}
+
+fn into_robust_coord<N: Number + Into<f64>>(p: &impl Point<Number = N>) -> robust::Coord<N> {
+    robust::Coord { x: p.x(), y: p.y() }
+}
+
+#[derive(Debug)]
+pub struct DefaultGlobalFunctions<P: Point>(PhantomData<P>);
+impl<P: Point> DefaultGlobalFunctions<P> {
+    pub const fn const_new() -> Self {
+        Self(PhantomData)
+    }
+}
+impl<P: Point> Copy for DefaultGlobalFunctions<P> {}
+impl<P: Point> Clone for DefaultGlobalFunctions<P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<P: Point> Default for DefaultGlobalFunctions<P> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+impl<P: Point> GlobalFunctions for DefaultGlobalFunctions<P>
+where
+    P::Number: Into<f64>,
+{
+    type Point = P;
+    type Number = P::Number;
+
+    fn dist2(&self, p: &Self::Point, q: &Self::Point) -> Self::Number {
+        let dx = p.x() - q.x();
+        let dy = p.y() - q.y();
+        dx * dx + dy * dy
+    }
+
+    fn orient(&self, p: &Self::Point, q: &Self::Point, r: &Self::Point) -> Orient {
+        // Returns a **negative** value if ```self```, ```q``` and ```r``` occur in counterclockwise order (```r``` is to the left of the directed line ```self``` --> ```q```)
+        // Returns a **positive** value if they occur in clockwise order(```r``` is to the right of the directed line ```self``` --> ```q```)
+        // Returns zero is they are collinear
+        match orient2d(
+            into_robust_coord(p),
+            into_robust_coord(q),
+            into_robust_coord(r),
+        )
+        .partial_cmp(&0.0)
+        {
+            Some(Ordering::Less) => Orient::CounterClockwise,
+            Some(Ordering::Equal) => Orient::Collinear,
+            Some(Ordering::Greater) => Orient::Clockwise,
+            None => panic!("orient2d returned NaN"),
+        }
+    }
+
+    fn circumdelta(
+        &self,
+        p: &Self::Point,
+        b: &Self::Point,
+        c: &Self::Point,
+    ) -> (Self::Number, Self::Number) {
+        let dx = b.x() - p.x();
+        let dy = b.y() - p.y();
+        let ex = c.x() - p.x();
+        let ey = c.y() - p.y();
+
+        let bl = dx * dx + dy * dy;
+        let cl = ex * ex + ey * ey;
+        let d = Self::Number::ONE_HALF / (dx * ey - dy * ex);
+
+        let x = (ey * bl - dy * cl) * d;
+        let y = (dx * cl - ex * bl) * d;
+        (x, y)
+    }
+
+    fn circumradius2(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Number {
+        let (x, y) = self.circumdelta(p, b, c);
+        x * x + y * y
+    }
+
+    fn circumcenter(&self, p: &Self::Point, b: &Self::Point, c: &Self::Point) -> Self::Point {
+        let (x, y) = self.circumdelta(p, b, c);
+        Self::Point::new_point(p.x() + x, p.y() + y)
+    }
+
+    fn in_circle(
+        &self,
+        s: &Self::Point,
+        b: &Self::Point,
+        c: &Self::Point,
+        p: &Self::Point,
+    ) -> bool {
+        let dx = s.x() - p.x();
+        let dy = s.y() - p.y();
+        let ex = b.x() - p.x();
+        let ey = b.y() - p.y();
+        let fx = c.x() - p.x();
+        let fy = c.y() - p.y();
+
+        let ap = dx * dx + dy * dy;
+        let bp = ex * ex + ey * ey;
+        let cp = fx * fx + fy * fy;
+
+        dx * (ey * cp - bp * fy) - dy * (ex * cp - bp * fx) + ap * (ex * fy - ey * fx)
+            < Self::Number::ZERO
+    }
+
+    fn nearly_equals(&self, s: &Self::Point, p: &Self::Point) -> bool {
+        (s.x() - p.x()).abs() <= Self::Number::EPSILON
+            && (s.y() - p.y()).abs() <= Self::Number::EPSILON
+    }
+
+    fn sort_slice_by<T>(&self, s: &mut [T], f: impl FnMut(&T, &T) -> Ordering) {
+        s.sort_unstable_by(f)
+    }
+}
+
+pub trait Point: Clone {
+    type Number: Number;
+
+    fn new_point(x: Self::Number, y: Self::Number) -> Self
+    where
+        Self: Sized;
+    fn x(&self) -> Self::Number;
+    fn y(&self) -> Self::Number;
+
+    fn from_point(p: &impl Point<Number = Self::Number>) -> Self {
+        Self::new_point(p.x(), p.y())
+    }
+    fn to_point<P: Point<Number = Self::Number>>(&self) -> P {
+        P::from_point(self)
+    }
+    fn into_point<P: Point<Number = Self::Number>>(self) -> P {
+        P::from_point(&self)
+    }
+}
+
+pub trait Number:
+    Copy
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + PartialOrd
+{
+    /// Near-duplicate points (where both `x` and `y` only differ within this value)
+    /// will not be included in the triangulation for robustness.
+    ///
+    /// `std` implementations use `f{32,64}::EPSILON * 2.0`
+    const EPSILON: Self;
+
+    const ZERO: Self;
+    const ONE_HALF: Self;
+    const ONE: Self;
+    const TWO: Self;
+    const THREE: Self;
+    const FOUR: Self;
+
+    const INFINITY: Self;
+    const NEG_INFINITY: Self;
+
+    fn abs(self) -> Self;
+    fn floor(self) -> Self;
+    fn sqrt(self) -> Self;
+
+    fn from_usize_truncate(n: usize) -> Self;
+    fn into_usize_truncate(self) -> usize;
+
+    fn max(self, other: Self) -> Self;
+    fn min(self, other: Self) -> Self;
+}
+
+impl<N> Point for robust::Coord<N>
+where
+    N: Number + Into<f64>,
+{
+    type Number = N;
+
+    #[inline]
+    fn new_point(x: Self::Number, y: Self::Number) -> Self
+    where
+        Self: Sized,
+    {
+        Self { x, y }
+    }
+
+    #[inline]
+    fn x(&self) -> Self::Number {
+        self.x
+    }
+
+    #[inline]
+    fn y(&self) -> Self::Number {
+        self.y
+    }
+}
+impl<N> Point for (N, N)
+where
+    N: Number,
+{
+    type Number = N;
+
+    #[inline]
+    fn new_point(x: Self::Number, y: Self::Number) -> Self {
+        (x, y)
+    }
+
+    #[inline]
+    fn x(&self) -> Self::Number {
+        self.0
+    }
+
+    #[inline]
+    fn y(&self) -> Self::Number {
+        self.1
+    }
+}
+impl<N> Point for [N; 2]
+where
+    N: Number,
+{
+    type Number = N;
+
+    #[inline]
+    fn new_point(x: Self::Number, y: Self::Number) -> Self {
+        [x, y]
+    }
+
+    #[inline]
+    fn x(&self) -> Self::Number {
+        self[0]
+    }
+
+    #[inline]
+    fn y(&self) -> Self::Number {
+        self[1]
+    }
+}
+
+impl Number for f64 {
+    const EPSILON: Self = f64::EPSILON * 2.0;
+
+    const ZERO: Self = 0.0;
+    const ONE_HALF: Self = 0.5;
+    const ONE: Self = 1.0;
+    const TWO: Self = 2.0;
+    const THREE: Self = 3.0;
+    const FOUR: Self = 4.0;
+
+    const INFINITY: Self = f64::INFINITY;
+    const NEG_INFINITY: Self = f64::NEG_INFINITY;
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn abs(self) -> Self {
+        f64::abs(self)
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    fn abs(self) -> Self {
+        const SIGN_BIT: u64 = 1 << 63;
+        f64::from_bits(f64::to_bits(f) & !SIGN_BIT)
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn floor(self) -> Self {
+        f64::floor(self)
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    fn floor(self) -> Self {
+        let mut res = (self as i64) as f64;
+        if res > self {
+            res -= 1.0;
+        }
+        res as f64
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn sqrt(self) -> Self {
+        f64::sqrt(self)
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    fn sqrt(self) -> Self {
+        if self < 2.0 {
+            return self;
+        };
+
+        let sc = Number::sqrt(self / 4.0) * 2.0;
+        let lc = sc + 1.0;
+
+        if lc * lc > self {
+            sc
+        } else {
+            lc
+        }
+    }
+
+    #[inline]
+    fn from_usize_truncate(n: usize) -> Self {
+        n as Self
+    }
+
+    #[inline]
+    fn into_usize_truncate(self) -> usize {
+        self as usize
+    }
+
+    #[inline]
+    fn max(self, other: Self) -> Self {
+        f64::max(self, other)
+    }
+
+    #[inline]
+    fn min(self, other: Self) -> Self {
+        f64::min(self, other)
+    }
+}
+impl Number for f32 {
+    const EPSILON: Self = f32::EPSILON * 2.0;
+
+    const ZERO: Self = 0.0;
+    const ONE_HALF: Self = 0.5;
+    const ONE: Self = 1.0;
+    const TWO: Self = 2.0;
+    const THREE: Self = 3.0;
+    const FOUR: Self = 4.0;
+
+    const INFINITY: Self = f32::INFINITY;
+    const NEG_INFINITY: Self = f32::NEG_INFINITY;
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn abs(self) -> Self {
+        f32::abs(self)
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    fn abs(self) -> Self {
+        const SIGN_BIT: u32 = 1 << 31;
+        f32::from_bits(f32::to_bits(self) & !SIGN_BIT)
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn floor(self) -> Self {
+        f32::floor(self)
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    fn floor(self) -> Self {
+        let mut res = (self as i32) as f32;
+        if res > self {
+            res -= 1.0;
+        }
+        res as f32
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    fn sqrt(self) -> Self {
+        f32::sqrt(self)
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline]
+    fn sqrt(self) -> Self {
+        if self < 2.0 {
+            return self;
+        };
+
+        let sc = Number::sqrt(self / 4.0) * 2.0;
+        let lc = sc + 1.0;
+
+        if lc * lc > self {
+            sc
+        } else {
+            lc
+        }
+    }
+
+    #[inline]
+    fn from_usize_truncate(n: usize) -> Self {
+        n as Self
+    }
+
+    #[inline]
+    fn into_usize_truncate(self) -> usize {
+        self as usize
+    }
+
+    #[inline]
+    fn max(self, other: Self) -> Self {
+        f32::max(self, other)
+    }
+
+    #[inline]
+    fn min(self, other: Self) -> Self {
+        f32::min(self, other)
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "robust")]
+
 use delaunator::{
     triangulate, DefaultGlobalFunctions, GlobalFunctions, Number, Orient, Point, Triangulation,
     EMPTY,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,9 @@
-use delaunator::{triangulate, Point, Triangulation, EMPTY, EPSILON};
-use std::f64;
+use delaunator::{
+    triangulate, DefaultGlobalFunctions, GlobalFunctions, Number, Orient, Point, Triangulation,
+    EMPTY,
+};
+use serde::de::DeserializeOwned;
+use std::fmt::{Debug, Display};
 use std::fs::File;
 
 macro_rules! test_fixture {
@@ -7,15 +11,16 @@ macro_rules! test_fixture {
         #[test]
         fn $fixture_name() {
             let path = format!("tests/fixtures/{}.json", stringify!($fixture_name));
-            let points = load_fixture(&path);
-            validate(&points);
+            validate(&load_fixture::<[f32; 2]>(&path));
+            validate(&load_fixture::<[f64; 2]>(&path));
         }
     };
 }
 
 #[test]
 fn basic() {
-    validate(&load_fixture("tests/fixtures/basic.json"));
+    validate(&load_fixture::<[f32; 2]>("tests/fixtures/basic.json"));
+    validate(&load_fixture::<[f64; 2]>("tests/fixtures/basic.json"));
 }
 
 test_fixture!(robust2);
@@ -36,13 +41,22 @@ test_fixture!(issue44js);
 
 #[test]
 fn robustness() {
-    let points = load_fixture("tests/fixtures/robust1.json");
+    let points_f32 = load_fixture::<[f32; 2]>("tests/fixtures/robust1.json");
 
-    validate(&points);
-    validate(&(scale_points(&points, 1e-9)));
-    validate(&(scale_points(&points, 1e-2)));
-    validate(&(scale_points(&points, 100.0)));
-    validate(&(scale_points(&points, 1e9)));
+    validate(&points_f32);
+    // f32 does not have enough precision to handle this scale
+    // validate(&(scale_points(points_f32.iter().copied(), 1e-9)));
+    validate(&(scale_points(points_f32.iter().copied(), 1e-2)));
+    validate(&(scale_points(points_f32.iter().copied(), 100.0)));
+    validate(&(scale_points(points_f32.iter().copied(), 1e9)));
+
+    let points_f64 = load_fixture::<[f64; 2]>("tests/fixtures/robust1.json");
+
+    validate(&points_f64);
+    validate(&(scale_points(points_f64.iter().copied(), 1e-9)));
+    validate(&(scale_points(points_f64.iter().copied(), 1e-2)));
+    validate(&(scale_points(points_f64.iter().copied(), 100.0)));
+    validate(&(scale_points(points_f64.iter().copied(), 1e9)));
 }
 
 #[test]
@@ -58,7 +72,7 @@ fn bad_input() {
     assert!(halfedges.is_empty(), "Expected no edges (0 point)");
     assert!(hull.is_empty(), "Expected no hull (0 point)");
 
-    points.push(Point { x: 0., y: 0. });
+    points.push([0., 0.]);
     let Triangulation {
         triangles,
         halfedges,
@@ -69,7 +83,7 @@ fn bad_input() {
     assert!(halfedges.is_empty(), "Expected no edges (1 point)");
     assert!(hull.len() == 1, "Expected single point on hull (1 point)");
 
-    points.push(Point { x: 1., y: 0. });
+    points.push([1., 0.]);
     let Triangulation {
         triangles,
         halfedges,
@@ -84,7 +98,7 @@ fn bad_input() {
         "Expected ordered hull points (2 point)"
     );
 
-    points.push(Point { x: 2., y: 0. });
+    points.push([2., 0.]);
     let Triangulation {
         triangles,
         halfedges,
@@ -99,8 +113,9 @@ fn bad_input() {
         halfedges.is_empty(),
         "Expected no edges (3 collinear points)"
     );
-    assert!(
-        hull.len() == 3,
+    assert_eq!(
+        hull.len(),
+        3,
         "Expected three points on hull (3 collinear points)"
     );
     assert!(
@@ -108,18 +123,15 @@ fn bad_input() {
         "Expected ordered hull points (3 collinear points)"
     );
 
-    points.push(Point { x: 1., y: 1. });
+    points.push([1., 1.]);
     validate(&points);
 }
 
 #[test]
 fn unordered_collinear_points_input() {
-    let points: Vec<Point> = [10, 2, 4, 4, 1, 0, 3, 6, 8, 5, 7, 9]
+    let points: Vec<_> = [10, 2, 4, 4, 1, 0, 3, 6, 8, 5, 7, 9]
         .iter()
-        .map(|y| Point {
-            x: 0.0,
-            y: *y as f64,
-        })
+        .map(|y| (0.0, *y as f64))
         .collect();
     let duplicated = 1;
 
@@ -137,21 +149,24 @@ fn unordered_collinear_points_input() {
         halfedges.is_empty(),
         "Expected no edges (unordered collinear points)"
     );
-    assert!(
-        hull.len() == points.len() - duplicated,
+    assert_eq!(
+        hull.len(),
+        points.len() - duplicated,
         "Expected all non-coincident points on hull (unordered collinear points)"
     );
     assert!(
         hull.iter()
             .enumerate()
-            .all(|(i, v)| points[*v].y == (i as f64)),
+            .all(|(i, v)| points[*v].y() == (i as f64)),
         "Expected ordered hull points (unordered collinear points)"
     );
 }
 
 #[test]
 fn hull_collinear_issue24() {
-    let points = load_fixture("tests/fixtures/issue24.json");
+    validate(&load_fixture::<[f32; 2]>("tests/fixtures/issue24.json"));
+
+    let points = load_fixture::<[f64; 2]>("tests/fixtures/issue24.json");
     validate(&points);
 
     let t = triangulate(&points);
@@ -163,51 +178,28 @@ fn hull_collinear_issue24() {
 /// In this test, the output does not matter as long as an output is returned.
 fn invalid_nan_sequence() {
     let points = vec![
-        Point { x: -3.5, y: -1.5 },
-        Point {
-            x: f64::NAN,
-            y: f64::NAN,
-        },
-        Point {
-            x: f64::NAN,
-            y: f64::NAN,
-        },
-        Point { x: -3.5, y: -1.5 },
+        (-3.5, -1.5),
+        (f64::NAN, f64::NAN),
+        (f64::NAN, f64::NAN),
+        (-3.5, -1.5),
     ];
     triangulate(&points);
 }
 
-#[test]
-/// The test demonstrates and validates our tuple and array round tripping of `Point`
-fn tuple_array_conv() {
-    // Tuple/Array --> Point
-    assert_eq!(Into::<Point>::into((1., 2.)), Point { x: 1., y: 2. });
-    assert_eq!(Into::<Point>::into([1., 2.]), Point { x: 1., y: 2. });
-
-    // Point --> Tuple/Array
-    assert_eq!(Into::<(f64, f64)>::into(Point { x: 1., y: 2. }), (1., 2.));
-    assert_eq!(Into::<[f64; 2]>::into(Point { x: 1., y: 2. }), [1., 2.]);
+fn scale_points<P: Point>(points: impl IntoIterator<Item = P>, scale: P::Number) -> Vec<P> {
+    points
+        .into_iter()
+        .map(move |p| P::new_point(p.x() * scale, p.y() * scale))
+        .collect()
 }
 
-fn scale_points(points: &[Point], scale: f64) -> Vec<Point> {
-    let scaled: Vec<Point> = points
-        .iter()
-        .map(|p| Point {
-            x: p.x * scale,
-            y: p.y * scale,
-        })
-        .collect();
-    scaled
-}
-
-fn load_fixture(path: &str) -> Vec<Point> {
+fn load_fixture<P: Point>(path: &str) -> Vec<P>
+where
+    P::Number: DeserializeOwned,
+{
     let file = File::open(path).unwrap();
-    let u: Vec<(f64, f64)> = serde_json::from_reader(file).unwrap();
-    u.iter().map(|p| Point { x: p.0, y: p.1 }).collect()
-}
-
-fn orient(p: &Point, q: &Point, r: &Point) -> f64 {
-    robust::orient2d(p.into(), q.into(), r.into())
+    let u: Vec<(P::Number, P::Number)> = serde_json::from_reader(file).unwrap();
+    u.iter().map(|p| Point::new_point(p.0, p.1)).collect()
 }
 
 /// make sure hull is convex and counter-clockwise (p1 is to the right of the directed line p0 --> p2)
@@ -216,25 +208,25 @@ fn orient(p: &Point, q: &Point, r: &Point) -> f64 {
 //   \                           ^
 //    > p0 ---------------> p2 /
 //              p1
-fn assert_convex(p0: &Point, p1: &Point, p2: &Point) {
-    let l = orient(p0, p2, p1);
-    assert!(l >= 0., "p1 ({:?}) is to the left of the directed line p0 ({:?}) --> p2 ({:?}). Hull is not convex.", p1, p0, p2);
+fn assert_convex<N: Number + Into<f64>, P: Point<Number = N> + Debug>(p0: &P, p1: &P, p2: &P) {
+    let l = DefaultGlobalFunctions::<P>::const_new().orient(p0, p2, p1);
+    assert!(matches!(l, Orient::Clockwise | Orient::Collinear), "p1 ({:?}) is to the left of the directed line p0 ({:?}) --> p2 ({:?}). Hull is not convex.", p1, p0, p2);
 
-    if l == 0. {
+    if l == Orient::Collinear {
         // if p0, p1 and p2 are collinear, they must be ordered
         // that means that p1 - p0 = c * (p2 - p0), where c is (0..1) but not inclusive (linear combination)
-        let c = ((p1.x - p0.x) / (p2.x - p0.x)).max((p1.y - p0.y) / (p2.y - p0.y));
-        assert!(c > 0., "incorrect ordering, found p1, p0, p2, expected p0 ({:?}), p1 ({:?}), p2 ({:?}). Invalid hull.", p0, p1, p2);
-        assert!(c < 1., "incorrect ordering, found p0, p2, p1, expected p0 ({:?}), p1 ({:?}), p2 ({:?}). Invalid hull.", p0, p1, p2);
+        let c = ((p1.x() - p0.x()) / (p2.x() - p0.x())).max((p1.y() - p0.y()) / (p2.y() - p0.y()));
+        assert!(c > N::ZERO, "incorrect ordering, found p1, p0, p2, expected p0 ({:?}), p1 ({:?}), p2 ({:?}). Invalid hull.", p0, p1, p2);
+        assert!(c < N::ONE, "incorrect ordering, found p0, p2, p1, expected p0 ({:?}), p1 ({:?}), p2 ({:?}). Invalid hull.", p0, p1, p2);
     }
 }
 
-fn validate(points: &[Point]) {
+fn validate<N: Number + Display + Into<f64>>(points: &[impl Point<Number = N> + Debug]) {
     let Triangulation {
         triangles,
         halfedges,
         hull,
-    } = triangulate(&points);
+    } = triangulate(points);
 
     // validate halfedges
     for (i, &h) in halfedges.iter().enumerate() {
@@ -252,10 +244,10 @@ fn validate(points: &[Point]) {
             let p1 = &points[hull[(i + 1) % hull.len()]];
             let p2 = &points[hull[(i + 2) % hull.len()]];
             assert_convex(p0, p1, p2);
-            hull_areas.push((p1.x - p0.x) * (p1.y + p0.y));
+            hull_areas.push((p1.x() - p0.x()) * (p1.y() + p0.y()));
         }
 
-        sum(&hull_areas)
+        sum(hull_areas)
     };
     let triangles_area = {
         let mut triangle_areas = Vec::new();
@@ -264,30 +256,33 @@ fn validate(points: &[Point]) {
             let a = &points[triangles[i]];
             let b = &points[triangles[i + 1]];
             let c = &points[triangles[i + 2]];
-            triangle_areas.push(((b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y)).abs());
+            triangle_areas.push(
+                ((b.y() - a.y()) * (c.x() - b.x()) - (b.x() - a.x()) * (c.y() - b.y())).abs(),
+            );
             i += 3;
         }
-        sum(&triangle_areas)
+        sum(triangle_areas)
     };
 
     let err = ((hull_area - triangles_area) / hull_area).abs();
-    if err > EPSILON {
+    if err > N::EPSILON {
         panic!("Triangulation is broken: {} error", err);
     }
 }
 
 // Kahan and Babuska summation, Neumaier variant; accumulates less FP error
-fn sum(x: &[f64]) -> f64 {
-    let mut sum = x[0];
-    let mut err: f64 = 0.0;
-    for i in 1..x.len() {
-        let k = x[i];
+fn sum<N: Number>(x: impl IntoIterator<Item = N>) -> N {
+    let mut iter = x.into_iter();
+    let mut sum = iter.next().unwrap_or(N::ZERO);
+    let mut err = N::ZERO;
+    for k in iter {
         let m = sum + k;
-        err += if sum.abs() >= k.abs() {
-            sum - m + k
-        } else {
-            k - m + sum
-        };
+        err = err
+            + if sum.abs() >= k.abs() {
+                sum - m + k
+            } else {
+                k - m + sum
+            };
         sum = m;
     }
     sum + err

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,6 @@
-#![cfg(feature = "robust")]
-
 use delaunator::{
-    triangulate, DefaultGlobalFunctions, GlobalFunctions, Number, Orient, Point, Triangulation,
-    EMPTY,
+    point_ext::{Orient, PointExt},
+    triangulate, Number, Point, Triangulation, EMPTY,
 };
 use serde::de::DeserializeOwned;
 use std::fmt::{Debug, Display};
@@ -211,7 +209,7 @@ where
 //    > p0 ---------------> p2 /
 //              p1
 fn assert_convex<N: Number + Into<f64>, P: Point<Number = N> + Debug>(p0: &P, p1: &P, p2: &P) {
-    let l = DefaultGlobalFunctions::<P>::const_new().orient(p0, p2, p1);
+    let l = p0.orient(p2, p1);
     assert!(matches!(l, Orient::Clockwise | Orient::Collinear), "p1 ({:?}) is to the left of the directed line p0 ({:?}) --> p2 ({:?}). Hull is not convex.", p1, p0, p2);
 
     if l == Orient::Collinear {


### PR DESCRIPTION
Fixes #4 
Closes #39 

Features:
- Generic number support, users can add custom types in addition to f32 and f64. A good addition would be f128 (only for supported hardware).
- custom optimized functions for specific hardware/requirements. Default interface is still similar and performs the same. (#39 can use this to replace the unstable sorting)
- ~~`robust` is now optional but global functions need to be manually provided.~~